### PR TITLE
Fix AbstractCompilerPassTest class name

### DIFF
--- a/PhpUnit/AbstractCompilerPassTestCase.php
+++ b/PhpUnit/AbstractCompilerPassTestCase.php
@@ -4,7 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-abstract class AbstractCompilerPassTest extends AbstractContainerBuilderTestCase
+abstract class AbstractCompilerPassTestCase extends AbstractContainerBuilderTestCase
 {
     /**
      * Register the compiler pass under test, just like you would do inside a bundle's load()

--- a/Tests/PhpUnit/AbstractCompilerPassTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractCompilerPassTestCaseTest.php
@@ -2,14 +2,14 @@
 
 namespace Matthias\DependencyInjectionTests\Tests\PhpUnit;
 
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTest;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\CollectServicesAndAddThemWithMethodCallsCompilerPass;
 use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\CollectServicesAndSetThemAsArgumentCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class AbstractCompilerPassTestCaseTest extends AbstractCompilerPassTest
+class AbstractCompilerPassTestCaseTest extends AbstractCompilerPassTestCase
 {
     protected function registerCompilerPass(ContainerBuilder $container)
     {


### PR DESCRIPTION
Per the docs for testing compiler passes, the name of the class's own test class, and the naming scheme of the other Abstract\* classes in the PhpUnit directory, the AbstractCompilerPassTest class should actually be named AbstractCompilerPassTestCase.
