### PR TITLE
Move requirements to prod requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "matthiasnoback/symfony-config-test": "0.*",
-        "symfony/dependency-injection": "2.3.*",
+        "symfony/dependency-injection": "2.*",
         "phpunit/phpunit": "3.*"
     },
     "target-dir": "Matthias/SymfonyDependencyInjectionTest",


### PR DESCRIPTION
Only prod requirements of installed packages are loaded. These requirements are all prod requirements in order to get this (test) library working
