### PR TITLE
Added support for synthetic services

### DIFF
--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -72,9 +72,15 @@ class ContainerBuilderHasServiceDefinitionConstraint extends \PHPUnit_Framework_
 
     private function evaluateClass(ContainerBuilder $containerBuilder, $returnResult)
     {
-        $definition = $containerBuilder->findDefinition($this->serviceId);
+        try {
+            $definition = $containerBuilder->findDefinition($this->serviceId);
+            $actualClass = $definition->getClass();
+        } catch (DiException\InvalidArgumentException $e) {
+            // synthetic service
+            $serviceReflection = new \ReflectionObject($containerBuilder->get($this->serviceId));
+            $actualClass = $serviceReflection->getName();
+        }
 
-        $actualClass = $definition->getClass();
 
         $constraint = new \PHPUnit_Framework_Constraint_IsEqual($this->expectedClass);
 


### PR DESCRIPTION
Synthetic services doesn't have a definition, they are only accessible using `get()`.

At first, I thought a new constraint was better since this constraint is called ContainerBuilderHas<b>ServiceDefinition</b>Constraint, which does not apply to synthetic services. However, the assert method is `assertContainerBuilderHasService()`, which doesn't talk about definitions specificly. Changing that method name to `assertContainerBuilderHasServiceDefinition()` and using `assertContainerBuilderHasService()` for synthetic services looked like a huge BC break to me.
