### PR TITLE
Made arguments argument optional for method calls

### DIFF
--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -157,7 +157,7 @@ abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestC
     protected function assertContainerBuilderHasServiceDefinitionWithMethodCall(
         $serviceId,
         $method,
-        array $arguments
+        array $arguments = array()
     ) {
         $definition = $this->container->findDefinition($serviceId);
 

--- a/PhpUnit/DefinitionHasMethodCallConstraint.php
+++ b/PhpUnit/DefinitionHasMethodCallConstraint.php
@@ -9,7 +9,7 @@ class DefinitionHasMethodCallConstraint extends \PHPUnit_Framework_Constraint
     private $methodName;
     private $arguments;
 
-    public function __construct($methodName, array $arguments)
+    public function __construct($methodName, array $arguments = array())
     {
         $this->methodName = $methodName;
         $this->arguments = $arguments;

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ These are the available semantic assertions for each of the test cases shown abo
 <dt><code>assertContainerBuilderHasServiceDefinitionWithArgument($serviceId, $argumentIndex, $expectedValue)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has an argument at
 the given index, and its value is the given value.</dd>
-<dt><code>assertContainerBuilderHasServiceDefinitionWithMethodCall($serviceId, $method, array $arguments)</code></dt>
+<dt><code>assertContainerBuilderHasServiceDefinitionWithMethodCall($serviceId, $method, array $arguments = array())</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has a method call to
 the given method with the given arguments.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithParent($serviceId, $parentServiceId)</code></dt>


### PR DESCRIPTION
When no arguments should be passed to a method call, it's nicer to only
provide the method call without also having to pass an empty array.

Besides that it's nicer, it's also consistent with how you can define
method calls on the ContainerBuilder.
