### PR TITLE
Added constraint for definition with tags

### DIFF
--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -165,6 +165,24 @@ abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestC
     }
 
     /**
+     * Assert that the ContainerBuilder for this test has a service definition with the given id, which has a tag
+     * with the given attributes.
+     *
+     * @param string $serviceId
+     * @param string $tag
+     * @param array  $attributes
+     */
+    protected function assertContainerBuilderHasServiceDefinitionWithTag(
+        $serviceId,
+        $tag,
+        array $attributes = array()
+    ) {
+        $definition = $this->container->findDefinition($serviceId);
+
+        self::assertThat($definition, new DefinitionHasTagConstraint($tag, $attributes));
+    }
+
+    /**
      * Assert that the ContainerBuilder for this test has a service definition with the given id which is a decorated
      * service and it has the given parent service.
      *

--- a/PhpUnit/DefinitionHasTagConstraint.php
+++ b/PhpUnit/DefinitionHasTagConstraint.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+class DefinitionHasTagConstraint extends \PHPUnit_Framework_Constraint
+{
+    private $name;
+    private $attributes;
+
+    public function __construct($name, array $attributes = array())
+    {
+        $this->name = $name;
+        $this->attributes = $attributes;
+    }
+
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        if (!($other instanceof Definition)) {
+            throw new \InvalidArgumentException(
+                'Expected an instance of Symfony\Component\DependencyInjection\Definition'
+            );
+        }
+
+        foreach ($other->getTags() as $tagName => $tagsAttributes) {
+            if ($tagName !== $this->name) {
+                continue;
+            }
+
+            foreach ($tagsAttributes as $tagAttributes) {
+                if ($this->equalAttributes($this->attributes, $tagAttributes)) {
+                    return true;
+                }
+            }
+
+            if (!$returnResult) {
+                $this->fail(
+                    $other,
+                    sprintf(
+                        'None of the tags matched the expected name "%s" with attributes %s',
+                        $this->name,
+                        \PHPUnit_Util_Type::export($this->attributes)
+                    )
+                );
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    public function toString()
+    {
+        return sprintf(
+            'has the "%s" tag with the given attributes',
+            $this->name
+        );
+    }
+
+    private function equalAttributes($expectedAttributes, $actualAttributes)
+    {
+        $constraint = new \PHPUnit_Framework_Constraint_IsEqual(
+            $expectedAttributes
+        );
+
+        return $constraint->evaluate($actualAttributes, '', true);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ the given index, and its value is the given value.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithMethodCall($serviceId, $method, array $arguments = array())</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has a method call to
 the given method with the given arguments.</dd>
+<dt><code>assertContainerBuilderHasServiceDefinitionWithTag($serviceId, $tag, array $attributes = array())</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has the given tag with the given arguments.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithParent($serviceId, $parentServiceId)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id which is a decorated service and it has the given parent service.</dd>
 </dl>

--- a/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionHasTagConstraint;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DefinitionHasTagConstraintTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @dataProvider definitionProvider
+     */
+    public function match(Definition $definition, $tag, $attributes, $expectedToMatch)
+    {
+        $constraint = new DefinitionHasTagConstraint($tag, $attributes);
+
+        $this->assertSame($expectedToMatch, $constraint->evaluate($definition, '', true));
+    }
+
+    public function definitionProvider()
+    {
+        $definitionWithoutTags = new Definition();
+        $definitionWithTwoTags = new Definition();
+
+        $tag = 'some_provider';
+
+        $attributesOfFirstTag = array('name' => 'attribute of first tag');
+        $definitionWithTwoTags->addTag($tag, $attributesOfFirstTag);
+
+        $attributesOfSecondTag = array('name' => 'attributes of second tag');
+        $definitionWithTwoTags->addTag($tag, $attributesOfSecondTag);
+
+        $otherAttributes = array('name' => 'some other attribute');
+
+        return array(
+            // the definition has no tags
+            array($definitionWithoutTags, $tag, array(), false),
+            // the definition has this tag, attributes match with the first tag
+            array($definitionWithTwoTags, $tag, $attributesOfFirstTag, true),
+            // the definition has this tag, attributes match with the second tag
+            array($definitionWithTwoTags, $tag, $attributesOfSecondTag, true),
+            // the definition has this tag, but the attributes don't match
+            array($definitionWithTwoTags, $tag, $otherAttributes, false),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_string_representation()
+    {
+        $tag = 'tagName';
+        $constraint = new DefinitionHasTagConstraint($tag, array());
+
+        $this->assertSame('has the "'.$tag.'" tag with the given attributes', $constraint->toString());
+    }
+}


### PR DESCRIPTION
It would be nice if we can test if a specific service definition has a
tag.

An example use case: https://github.com/symfony-cmf/SeoBundle/pull/129/files#r11394457
