### PR TITLE
Made values optional for some assertContainerBuilderHas* assertions.

### DIFF
--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -76,11 +76,13 @@ abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestC
      * @param $serviceId
      * @param $expectedClass
      */
-    protected function assertContainerBuilderHasService($serviceId, $expectedClass)
+    protected function assertContainerBuilderHasService($serviceId, $expectedClass = null)
     {
+        $checkExpectedClass = (func_num_args() > 1);
+
         self::assertThat(
             $this->container,
-            new ContainerBuilderHasServiceDefinitionConstraint($serviceId, $expectedClass)
+            new ContainerBuilderHasServiceDefinitionConstraint($serviceId, $expectedClass, $checkExpectedClass)
         );
     }
 
@@ -103,7 +105,7 @@ abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestC
      * @param $aliasId
      * @param $expectedServiceId
      */
-    protected function assertContainerBuilderHasAlias($aliasId, $expectedServiceId)
+    protected function assertContainerBuilderHasAlias($aliasId, $expectedServiceId = null)
     {
         self::assertThat(
             $this->container,
@@ -117,11 +119,13 @@ abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestC
      * @param $parameterName
      * @param $expectedParameterValue
      */
-    protected function assertContainerBuilderHasParameter($parameterName, $expectedParameterValue)
+    protected function assertContainerBuilderHasParameter($parameterName, $expectedParameterValue = null)
     {
+        $checkParameterValue = (func_num_args() > 1);
+
         self::assertThat(
             $this->container,
-            new ContainerHasParameterConstraint($parameterName, $expectedParameterValue)
+            new ContainerHasParameterConstraint($parameterName, $expectedParameterValue, $checkParameterValue)
         );
     }
 
@@ -136,13 +140,14 @@ abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestC
     protected function assertContainerBuilderHasServiceDefinitionWithArgument(
         $serviceId,
         $argumentIndex,
-        $expectedValue
+        $expectedValue = null
     ) {
         $definition = $this->container->findDefinition($serviceId);
+        $checkValue = (func_num_args() > 2);
 
         self::assertThat(
             $definition,
-            new DefinitionHasArgumentConstraint($argumentIndex, $expectedValue)
+            new DefinitionHasArgumentConstraint($argumentIndex, $expectedValue, $checkValue)
         );
     }
 

--- a/PhpUnit/ContainerBuilderHasAliasConstraint.php
+++ b/PhpUnit/ContainerBuilderHasAliasConstraint.php
@@ -11,13 +11,13 @@ class ContainerBuilderHasAliasConstraint extends \PHPUnit_Framework_Constraint
     private $expectedServiceId;
     protected $exporter;
 
-    public function __construct($aliasId, $expectedServiceId)
+    public function __construct($aliasId, $expectedServiceId = null)
     {
         if (!is_string($aliasId)) {
             throw new \InvalidArgumentException('The $aliasId argument should be a string');
         }
 
-        if (!is_string($expectedServiceId)) {
+        if ($expectedServiceId !== null && !is_string($expectedServiceId)) {
             throw new \InvalidArgumentException('The $expectedServiceId argument should be a string');
         }
 
@@ -43,7 +43,7 @@ class ContainerBuilderHasAliasConstraint extends \PHPUnit_Framework_Constraint
             return false;
         }
 
-        if (!$this->evaluateServiceId($other, $returnResult)) {
+        if ($this->expectedServiceId !== null && !$this->evaluateServiceId($other, $returnResult)) {
             return false;
         }
 

--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -9,20 +9,22 @@ class ContainerBuilderHasServiceDefinitionConstraint extends \PHPUnit_Framework_
 {
     private $serviceId;
     private $expectedClass;
+    private $checkExpectedClass;
     protected $exporter;
 
-    public function __construct($serviceId, $expectedClass)
+    public function __construct($serviceId, $expectedClass = null, $checkExpectedClass = true)
     {
         if (!is_string($serviceId)) {
             throw new \InvalidArgumentException('The $serviceId argument should be a string');
         }
 
-        if (!is_string($expectedClass)) {
+        if ($checkExpectedClass && !is_string($expectedClass)) {
             throw new \InvalidArgumentException('The $expectedClass argument should be a string');
         }
 
         $this->serviceId = $serviceId;
         $this->expectedClass = $expectedClass;
+        $this->checkExpectedClass = $checkExpectedClass;
         $this->exporter = new Exporter;
     }
 
@@ -47,7 +49,7 @@ class ContainerBuilderHasServiceDefinitionConstraint extends \PHPUnit_Framework_
             return false;
         }
 
-        if (!$this->evaluateClass($other, $returnResult)) {
+        if ($this->checkExpectedClass && !$this->evaluateClass($other, $returnResult)) {
             return false;
         }
 

--- a/PhpUnit/ContainerHasParameterConstraint.php
+++ b/PhpUnit/ContainerHasParameterConstraint.php
@@ -9,12 +9,14 @@ class ContainerHasParameterConstraint extends \PHPUnit_Framework_Constraint
 {
     private $parameterName;
     private $expectedParameterValue;
+    private $checkParameterValue;
     protected $exporter;
 
-    public function __construct($parameterName, $expectedParameterValue)
+    public function __construct($parameterName, $expectedParameterValue = null, $checkParameterValue = false)
     {
         $this->parameterName = $parameterName;
         $this->expectedParameterValue = $expectedParameterValue;
+        $this->checkParameterValue = $checkParameterValue;
         $this->exporter = new Exporter;
     }
 
@@ -38,7 +40,7 @@ class ContainerHasParameterConstraint extends \PHPUnit_Framework_Constraint
             return false;
         }
 
-        if (!$this->evaluateParameterValue($other, $returnResult)) {
+        if ($this->checkParameterValue && !$this->evaluateParameterValue($other, $returnResult)) {
             return false;
         }
 

--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -10,12 +10,14 @@ class DefinitionHasArgumentConstraint extends \PHPUnit_Framework_Constraint
 {
     private $argumentIndex;
     private $expectedValue;
+    private $checkExpectedValue;
     protected $exporter;
 
-    public function __construct($argumentIndex, $expectedValue)
+    public function __construct($argumentIndex, $expectedValue, $checkExpectedValue = true)
     {
         $this->argumentIndex = (integer)$argumentIndex;
         $this->expectedValue = $expectedValue;
+        $this->checkExpectedValue = $checkExpectedValue;
         $this->exporter = new Exporter;
     }
 
@@ -39,7 +41,7 @@ class DefinitionHasArgumentConstraint extends \PHPUnit_Framework_Constraint
             return false;
         }
 
-        if (!$this->evaluateArgumentValue($other, $returnResult)) {
+        if ($this->checkExpectedValue && !$this->evaluateArgumentValue($other, $returnResult)) {
             return false;
         }
 

--- a/README.md
+++ b/README.md
@@ -289,14 +289,23 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 These are the available semantic assertions for each of the test cases shown above:
 
 <dl>
+<dt><code>assertContainerBuilderHasService($serviceId)</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id.</dd>
 <dt><code>assertContainerBuilderHasService($serviceId, $expectedClass)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id and class.</dd>
 <dt><code>assertContainerBuilderHasSyntheticService($serviceId)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a synthetic service with the given id.</dd>
+<dt><code>assertContainerBuilderHasAlias($aliasId)</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has an alias.</dd>
 <dt><code>assertContainerBuilderHasAlias($aliasId, $expectedServiceId)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has an alias and that it is an alias for the given service id.</dd>
+<dt><code>assertContainerBuilderHasParameter($parameterName)</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has a parameter.</dd>
 <dt><code>assertContainerBuilderHasParameter($parameterName, $expectedParameterValue)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a parameter and that its value is the given value.</dd>
+<dt><code>assertContainerBuilderHasServiceDefinitionWithArgument($serviceId, $argumentIndex)</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has an argument at
+the given index.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithArgument($serviceId, $argumentIndex, $expectedValue)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has an argument at
 the given index, and its value is the given value.</dd>

--- a/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
@@ -29,15 +29,25 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
 
         // manually defined parameter
         $this->assertContainerBuilderHasParameter('manual_parameter', 'parameter value');
+        // Just check parameter exists, value will not be checked.
+        $this->assertContainerBuilderHasParameter('manual_parameter');
 
         // manually defined service
         $this->assertContainerBuilderHasService('manual_service_id', 'stdClass');
+        // Just check service exists, class will not be checked.
+        $this->assertContainerBuilderHasService('manual_service_id');
 
         // manually created alias
         $this->assertContainerBuilderHasAlias('manual_alias', 'service_id');
+        // Just check alias exists, service_id will not be checked.
+        $this->assertContainerBuilderHasAlias('manual_alias');
 
-        //
+        // manually overwritten argument
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('manual_service_id', 1, 'argument value');
+
+        // check for existence of manually created arguments, not checking values.
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('manual_service_id', 0);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('manual_service_id', 1);
     }
 
     /**

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -36,7 +36,9 @@ class ContainerBuilderHasAliasConstraintTest extends \PHPUnit_Framework_TestCase
             // the container has the alias, but for another service
             array($emptyContainerBuilder, $aliasId, $wrongServiceId, false),
             // the container has the alias for the right service id
-            array($builderWithAlias, $aliasId, $rightServiceId, true)
+            array($builderWithAlias, $aliasId, $rightServiceId, true),
+            // service id is optional
+            array($builderWithAlias, $aliasId, null, true),
         );
     }
 

--- a/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
@@ -12,9 +12,14 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends \PHPUnit_Framew
      * @test
      * @dataProvider containerBuilderProvider
      */
-    public function match(ContainerBuilder $containerBuilder, $serviceId, $expectedClass, $shouldMatch)
-    {
-        $constraint = new ContainerBuilderHasServiceDefinitionConstraint($serviceId, $expectedClass);
+    public function match(
+      ContainerBuilder $containerBuilder,
+      $serviceId,
+      $expectedClass,
+      $checkExpectedClass,
+      $shouldMatch
+    ) {
+        $constraint = new ContainerBuilderHasServiceDefinitionConstraint($serviceId, $expectedClass, $checkExpectedClass);
 
         $this->assertSame($shouldMatch, $constraint->evaluate($containerBuilder, '', true));
     }
@@ -45,17 +50,19 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends \PHPUnit_Framew
 
         return array(
             // the container does not have the service definition
-            array($emptyContainerBuilder, $serviceId, $rightClass, false),
+            array($emptyContainerBuilder, $serviceId, $rightClass, true, false),
             // the container has a service definition, but with the wrong class
-            array($containerBuilderWithServiceDefinition, $serviceId, $wrongClass, false),
+            array($containerBuilderWithServiceDefinition, $serviceId, $wrongClass, true, false),
             // the container has a service definition with the right class
-            array($containerBuilderWithServiceDefinition, $serviceId, $rightClass, true),
+            array($containerBuilderWithServiceDefinition, $serviceId, $rightClass, true, true),
             // the container has a service definition with the right class, but it's a parameter
-            array($containerBuilderWithServiceDefinitionWithParameterClass, $serviceId, $rightClass, true),
+            array($containerBuilderWithServiceDefinitionWithParameterClass, $serviceId, $rightClass, true, true),
             // the container has an alias, but with the wrong class
-            array($containerBuilderWithAlias, $aliasId, $wrongClass, false),
+            array($containerBuilderWithAlias, $aliasId, $wrongClass, true, false),
             // the container has an alias with the right class
-            array($containerBuilderWithAlias, $aliasId, $rightClass, true)
+            array($containerBuilderWithAlias, $aliasId, $rightClass, true, true),
+            // giving a class is optional
+            array($containerBuilderWithAlias, $aliasId, null, false, true),
         );
     }
 

--- a/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
+++ b/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
@@ -3,7 +3,6 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerHasParameterConstraint;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContainerHasParameterConstraintTest extends \PHPUnit_Framework_TestCase
@@ -12,9 +11,14 @@ class ContainerHasParameterConstraintTest extends \PHPUnit_Framework_TestCase
      * @test
      * @dataProvider containerBuilderProvider
      */
-    public function match(ContainerInterface $container, $parameterName, $parameterValue, $expectedToMatch)
-    {
-        $constraint = new ContainerHasParameterConstraint($parameterName, $parameterValue);
+    public function match(
+      ContainerInterface $container,
+      $parameterName,
+      $parameterValue,
+      $checkParameterValue,
+      $expectedToMatch
+    ) {
+        $constraint = new ContainerHasParameterConstraint($parameterName, $parameterValue, $checkParameterValue);
 
         $this->assertSame($expectedToMatch, $constraint->evaluate($container, '', true));
     }
@@ -35,11 +39,13 @@ class ContainerHasParameterConstraintTest extends \PHPUnit_Framework_TestCase
 
         return array(
             // the container does not have the parameter
-            array($emptyContainer, $parameterName, $parameterValue, false),
+            array($emptyContainer, $parameterName, $parameterValue, true, false),
             // the container has the parameter but the values don't match
-            array($containerWithParameter, $parameterName, $wrongParameterValue, false),
+            array($containerWithParameter, $parameterName, $wrongParameterValue, true, false),
             // the container has the parameter and the value matches
-            array($containerWithParameter, $parameterName, $parameterValue, true),
+            array($containerWithParameter, $parameterName, $parameterValue, true, true),
+            // the container has the parameter and the value is optional
+            array($containerWithParameter, $parameterName, null, false, true),
         );
     }
 


### PR DESCRIPTION
As discussed in #17, i made the check for concrete values for some assertContainerBuilderHas\* assertions optional.

As you mentioned mattiasnoback, there has been a problem with optional paramters. For `assertContainerBuilderHasParameter` and `assertContainerBuilderHasServiceDefinitionWithArgument` i used `func_num_args` to determine, if a value for a parameter should be checked.
This was done because `null` would a possible value for a parameter, that might be want to be checked also.

If this is ok, the README needs to be updated.
