### PR TITLE
fix AbstractCompilerPassTestCase when using strict-mode

### DIFF
--- a/PhpUnit/AbstractCompilerPassTestCase.php
+++ b/PhpUnit/AbstractCompilerPassTestCase.php
@@ -23,6 +23,9 @@ abstract class AbstractCompilerPassTestCase extends AbstractContainerBuilderTest
     {
         try {
             $this->compile();
+
+            // Ensure assertion for strict mode
+            $this->assertFalse($this->container->has('no_service'));
         } catch (\Exception $e) {
             $this->fail('The compiler pass should not fail with an empty container.');
         }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true" strict="true">
     <testsuites>
         <testsuite>
             <directory suffix="Test.php">./Tests</directory>


### PR DESCRIPTION
When running PHPUnit with strict mode `AbstractCompilerPassTestCase::compilation_should_not_fail_with_empty_container`

Failed with 'This test did not perform any assertions'.
