### PR TITLE
throw an exception when a definition doesn't provide the expected tags

### DIFF
--- a/PhpUnit/DefinitionHasTagConstraint.php
+++ b/PhpUnit/DefinitionHasTagConstraint.php
@@ -2,15 +2,18 @@
 
 namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
+use SebastianBergmann\Exporter\Exporter;
 use Symfony\Component\DependencyInjection\Definition;
 
 class DefinitionHasTagConstraint extends \PHPUnit_Framework_Constraint
 {
+    protected $exporter;
     private $name;
     private $attributes;
 
     public function __construct($name, array $attributes = array())
     {
+        $this->exporter = new Exporter();
         $this->name = $name;
         $this->attributes = $attributes;
     }
@@ -40,12 +43,20 @@ class DefinitionHasTagConstraint extends \PHPUnit_Framework_Constraint
                     sprintf(
                         'None of the tags matched the expected name "%s" with attributes %s',
                         $this->name,
-                        \PHPUnit_Util_Type::export($this->attributes)
+                        $this->exporter->export($this->attributes)
                     )
                 );
             }
 
+            if (!$returnResult) {
+                $this->fail($other, $description);
+            }
+
             return false;
+        }
+
+        if (!$returnResult) {
+            $this->fail($other, $description);
         }
 
         return false;

--- a/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
@@ -18,6 +18,26 @@ class DefinitionHasTagConstraintTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedToMatch, $constraint->evaluate($definition, '', true));
     }
 
+    /**
+     * @test
+     * @dataProvider definitionProvider
+     */
+    public function evaluateThrowsExceptionOnFailure(Definition $definition, $tag, $attributes, $expectedToMatch)
+    {
+        $constraint = new DefinitionHasTagConstraint($tag, $attributes);
+
+        if ($expectedToMatch) {
+            $this->assertTrue($constraint->evaluate($definition));
+        } else {
+            try {
+                $constraint->evaluate($definition);
+                $this->fail('DefinitionHasTagConstraint doesn\'t throw expected exception');
+            } catch (\PHPUnit_Framework_ExpectationFailedException $e) {
+                $this->assertTrue(true, 'DefinitionHasTagConstraint throws expected exception');
+            }
+        }
+    }
+
     public function definitionProvider()
     {
         $definitionWithoutTags = new Definition();


### PR DESCRIPTION
The `DefinitionHasTagConstraint` didn't work for me which means that the PHPUnit tests didn't fail when a definition didn't have the expected tags. It turned out that PHPUnit doesn't check the return value of a constraint's evaluate method. Instead, a constraint has to throw an exception when its check doesn't succeed.
