### PR TITLE
Check arguments in assertContainerBuilderHasServiceDefinitionWithMehodCall only if they were provided

### DIFF
--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -173,13 +173,13 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
      *
      * @param string $serviceId
      * @param string $method
-     * @param array $arguments
+     * @param array|null $arguments
      * @param int|null $index
      */
     protected function assertContainerBuilderHasServiceDefinitionWithMethodCall(
         $serviceId,
         $method,
-        array $arguments = array(),
+        array $arguments = null,
         $index = null
     ) {
         $definition = $this->container->findDefinition($serviceId);

--- a/PhpUnit/DefinitionHasMethodCallConstraint.php
+++ b/PhpUnit/DefinitionHasMethodCallConstraint.php
@@ -12,7 +12,7 @@ class DefinitionHasMethodCallConstraint extends Constraint
     private $arguments;
     private $index;
 
-    public function __construct($methodName, array $arguments = array(), $index = null)
+    public function __construct($methodName, array $arguments = null, $index = null)
     {
         if ($index !== null && !is_int($index)) {
             throw new \InvalidArgumentException(sprintf('Expected value of integer type for method call index, "%s" given.', is_object($index) ? get_class($index) : gettype($index)));
@@ -46,9 +46,11 @@ class DefinitionHasMethodCallConstraint extends Constraint
                 continue;
             }
 
-            if ($this->equalArguments($this->arguments, $arguments)) {
-                return true;
+            if (null !== $this->arguments && !$this->equalArguments($this->arguments, $arguments)) {
+                continue;
             }
+
+            return true;
         }
 
         if (!$returnResult) {

--- a/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
@@ -44,6 +44,8 @@ class DefinitionHasMethodCallConstraintTest extends TestCase
             array($definitionWithTwoMethodCalls, 'methodCallOne', $otherArguments, null, false),
             // the definition has a call to this method, arguments match with the first call, but invocation index is wrong
             array($definitionWithTwoMethodCalls, 'methodCallOne', $argumentsOfFirstCall, 1, false),
+            // the definition has a call to this method, has arguments, but they are not checked
+            array($definitionWithTwoMethodCalls, 'methodCallOne', null, null, true),
         );
     }
 


### PR DESCRIPTION
Hello, 

I was writing some compiler passes and noticed a little inconsistency - a lot of the `assertContainerBuilderHas*` methods have optional parameters, which is great, because you can choose the level of detail you want to check. This is especially needed if you are using a compiler pass to augment 3rd party code, where you don't have absolute control over it.

So for example `assertContainerBuilderHasServiceDefinitionWithArgument` takes argument value as a option and checks it only when given.

On the other hand `assertContainerBuilderHasServiceDefinitionWithMehodCall` has optional `arguments` parameter, but if you don't specify the argument, then the default is `[]` which means *check that there are no arguments*, which is totally different and could be confusing given the wording of the message (I got `has a method call to "setLogger" with the given arguments..`).

So I believe there is a need to differentiate *no arguments given to check* and *check that there are no arguments*, which I think can be translated as `null` vs `[]` and it would be understandable and even BC compatible, because if someone wants to check to empty array, they really should specify an empty array.

---

I think there may be other methods which accept arrays and behave similarly to the current state (`assertContainerBuilderHasServiceDefinitionWithTag`?), so If you will agree on this one with me and want me to, I can have a look at them too.