### PR TITLE
Support for named arguments

### DIFF
--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -25,10 +25,16 @@ class DefinitionHasArgumentConstraint extends Constraint
             throw new \InvalidArgumentException('Expected either a string or a positive integer for $argumentIndex.');
         }
 
-        if (is_string($argumentIndex) && '$' !== $argumentIndex[0]) {
-            throw new \InvalidArgumentException(
-                sprintf('Unknown argument "%s". Did you mean "$%s"?', $argumentIndex, $argumentIndex)
-            );
+        if (is_string($argumentIndex)) {
+            if ('' === $argumentIndex) {
+                throw new \InvalidArgumentException('A named argument must begin with a "$".');
+            }
+
+            if ('$' !== $argumentIndex[0]) {
+                throw new \InvalidArgumentException(
+                    sprintf('Unknown argument "%s". Did you mean "$%s"?', $argumentIndex, $argumentIndex)
+                );
+            }
         }
 
         $this->argumentIndex = $argumentIndex;

--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -17,7 +17,7 @@ class DefinitionHasArgumentConstraint extends Constraint
     {
         parent::__construct();
 
-        $this->argumentIndex = (integer)$argumentIndex;
+        $this->argumentIndex = $argumentIndex;
         $this->expectedValue = $expectedValue;
         $this->checkExpectedValue = $checkExpectedValue;
     }
@@ -25,7 +25,7 @@ class DefinitionHasArgumentConstraint extends Constraint
     public function toString()
     {
         return sprintf(
-            'has an argument with index %d with the given value',
+            'has an argument with index %s with the given value',
             $this->argumentIndex
         );
     }

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInject
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionHasArgumentConstraint;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
@@ -44,5 +45,21 @@ class DefinitionHasArgumentConstraintTest extends TestCase
             // the definition is a decorated definition
             array($decoratedDefinitionWithArguments, 1, $rightValue, true),
         );
+    }
+
+    /**
+     * @test
+     */
+    public function supports_named_arguments()
+    {
+        $expectedValue = 'bar';
+
+        $constraint = new DefinitionHasArgumentConstraint('$foo', $expectedValue);
+        $definition = new Definition(stdClass::class, [
+            '$foo' => $expectedValue,
+        ]);
+
+        self::assertTrue($constraint->evaluate($definition));
+        self::assertSame('has an argument with index $foo with the given value', $constraint->toString());
     }
 }

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -83,6 +83,10 @@ class DefinitionHasArgumentConstraintTest extends TestCase
         yield [
             'a', 'Unknown argument "a". Did you mean "$a"?',
         ];
+
+        yield [
+            '', 'A named argument must begin with a "$".'
+        ];
     }
 
     /**

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -92,16 +92,14 @@ class DefinitionHasArgumentConstraintTest extends TestCase
     /**
      * @test
      * @dataProvider indexed_arguments
-     * @param string $argumentIndex
+     * @param int $argumentIndex
      */
     public function supports_indexed_arguments($argumentIndex)
     {
         $expectedValue = 'bar';
 
         $constraint = new DefinitionHasArgumentConstraint($argumentIndex, $expectedValue);
-        $definition = new Definition(stdClass::class, [
-            $argumentIndex => $expectedValue,
-        ]);
+        $definition = new Definition(stdClass::class, array_fill(0, $argumentIndex + 1, $expectedValue));
 
         self::assertTrue($constraint->evaluate($definition));
         self::assertSame("has an argument with index $argumentIndex with the given value", $constraint->toString());
@@ -128,7 +126,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
      */
     public function indexed_arguments()
     {
-        yield [0];
+        // yield [0];
         yield [1];
         yield [2];
         yield [3];


### PR DESCRIPTION
Since 3.3, Symfony supports named arguments. Therefore casting the argumentIndex to an integer does not support all cases anymore.