### PR TITLE
Allow to use Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: SYMFONY_DI_VERSION=2.3.*
-    - php: 7.0
       env: SYMFONY_DI_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_DI_VERSION=2.8.*
     - php: 7.0
-      env: SYMFONY_DI_VERSION=3.2.*
+      env: SYMFONY_DI_VERSION=3.3.*
+    - php: 7.0
+      env: SYMFONY_DI_VERSION=4.0.*
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "require": {
         "php": "^7.0",
         "matthiasnoback/symfony-config-test": "^3.0",
-        "symfony/dependency-injection": "^2.3|^3.0",
-        "symfony/config": "^2.3|^3.0",
-        "symfony/yaml": "^2.7|^3.0"
+        "symfony/dependency-injection": "^2.7|^3.0|^4.0",
+        "symfony/config": "^2.7|^3.0|^4.0",
+        "symfony/yaml": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
Also dropped unmaintained version <2.7 from supported.

Fixes #82.