### PR TITLE
allow symfony 4.0 for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,55 @@
-sudo: false
-
 language: php
-
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=2.7.*
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=2.8.*
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=3.3.*
-    - php: 7.1
-      env: SYMFONY_DI_VERSION=4.0.*
-
+sudo: false
 cache:
-  directories:
-    - ~/.composer/cache/files
+    directories:
+        - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
+env:
+    global:
+        - PHPUNIT_FLAGS="-v"
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+matrix:
+    fast_finish: true
+    include:
+          # Minimum supported Symfony version with the latest PHP version
+        - php: 7.1
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+
+          # Test the latest stable release
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+          env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
+
+          # Force some major versions of Symfony
+        - php: 7.2
+          env: DEPENDENCIES="dunglas/symfony-lock:^2"
+        - php: 7.2
+          env: DEPENDENCIES="dunglas/symfony-lock:^3"
+        - php: 7.2
+          env: DEPENDENCIES="dunglas/symfony-lock:^4" STABILITY="beta"
+
+          # Latest commit to master
+        - php: 7.2
+          env: STABILITY="dev"
+
+    allow_failures:
+          # Dev-master is allowed to fail.
+        - env: STABILITY="dev"
 
 before_install:
-  - phpenv config-rm xdebug.ini || true
-  - composer self-update
+    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
+    - if ! [ -z "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
 install:
-  - if [ ! -z ${SYMFONY_DI_VERSION+x} ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_DI_VERSION}"; fi
-  - composer install --prefer-dist
+    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+    - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
 
-script: vendor/bin/phpunit
+script:
+    - composer validate --strict --no-check-lock
+    - ./vendor/bin/phpunit $PHPUNIT_FLAGS
 
 notifications:
   email: matthiasnoback@gmail.com
-
-cache:
-  directories:
-    - $COMPOSER_CACHE_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,36 +2,29 @@ sudo: false
 
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
-
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-      env: deps="low"
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=2.3.*
     - php: 7.0
       env: SYMFONY_DI_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_DI_VERSION=2.8.*
     - php: 7.0
-      env: SYMFONY_DI_VERSION=3.0.*
-  allow_failures:
-    - php: hhvm
+      env: SYMFONY_DI_VERSION=3.3.*
+    - php: 7.1
+      env: SYMFONY_DI_VERSION=4.0.*
 
-before_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
-  - if [ "$SYMFONY_DI_VERSION" != "" ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_DI_VERSION}"; fi
-  - if [ "$PHPUNIT_VERSION" != "" ]; then composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"; fi
-  - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
-  - if [ "$deps" = "" ]; then composer install; fi
+cache:
+  directories:
+    - ~/.composer/cache/files
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+  - composer self-update
+
+install:
+  - if [ ! -z ${SYMFONY_DI_VERSION+x} ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_DI_VERSION}"; fi
+  - composer install --prefer-dist
 
 script: vendor/bin/phpunit
 

--- a/PhpUnit/ContainerBuilderHasAliasConstraint.php
+++ b/PhpUnit/ContainerBuilderHasAliasConstraint.php
@@ -79,7 +79,7 @@ class ContainerBuilderHasAliasConstraint extends \PHPUnit_Framework_Constraint
          */
         $actualServiceId = (string) $alias;
 
-        $constraint = new \PHPUnit_Framework_Constraint_IsEqual(strtolower($this->expectedServiceId));
+        $constraint = new \PHPUnit_Framework_Constraint_IsEqual($this->expectedServiceId);
         if (!$constraint->evaluate($actualServiceId, '', true)) {
             if ($returnResult) {
                 return false;

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -73,16 +73,4 @@ class ContainerBuilderHasAliasConstraintTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\InvalidArgumentException', 'string');
         new ContainerBuilderHasAliasConstraint('alias_id', new \stdClass());
     }
-
-    /**
-     * @test
-     */
-    public function it_lower_cases_aliased_service_ids()
-    {
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setAlias('foo', 'fooBar');
-        $constraint = new ContainerBuilderHasAliasConstraint('foo', 'fooBar');
-
-        $this->assertTrue($constraint->evaluate($containerBuilder, null, true));
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "matthiasnoback/symfony-config-test": "^1.0 || ^2.0 || ^3.0",
+        "matthiasnoback/symfony-config-test": "^1.0 || ^2.0",
         "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
         "symfony/config": "^2.7 || ^3.3 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.3 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "matthiasnoback/symfony-config-test": "^1.0 || ^2.0",
+        "matthiasnoback/symfony-config-test": "^1.0 || ^2.0 || ^3.0",
         "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
         "symfony/config": "^2.7 || ^3.3 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.3 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,6 @@
             "homepage": "http://php-and-symfony.matthiasnoback.nl"
         }
     ],
-    "minimum-stability": "beta",
-    "prefer-stable": true,
     "require": {
         "matthiasnoback/symfony-config-test": "^1.0 || ^2.0",
         "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,17 @@
             "homepage": "http://php-and-symfony.matthiasnoback.nl"
         }
     ],
+    "minimum-stability": "beta",
+    "prefer-stable": true,
     "require": {
-        "matthiasnoback/symfony-config-test": "^1.0|^2.0",
-        "symfony/dependency-injection": "^2.3|^3.0",
-        "symfony/config": "^2.3|^3.0",
-        "symfony/yaml": "^2.7|^3.0",
-        "sebastian/exporter": "^1.0|^2.0"
+        "matthiasnoback/symfony-config-test": "^1.0 || ^2.0",
+        "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
+        "symfony/config": "^2.7 || ^3.3 || ^4.0",
+        "symfony/yaml": "^2.7 || ^3.3 || ^4.0",
+        "sebastian/exporter": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }


### PR DESCRIPTION
With this PR, we can require symfony 4.0 on packages where we require yours.

#SymfonyConHackday2017