### PR TITLE
Test with Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     include:
           # Minimum supported Symfony version with the latest PHP version
         - php: 7.1
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
           # Test the latest stable release
         - php: 7.0
@@ -46,11 +46,10 @@ install:
     # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
     - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
-    - vendor/bin/simple-phpunit install
 
 script:
     - composer validate --strict --no-check-lock
-    - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
+    - ./vendor/bin/phpunit $PHPUNIT_FLAGS
 
 notifications:
   email: matthiasnoback@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - php: 7.2
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
         - php: 7.2
-          env: DEPENDENCIES="dunglas/symfony-lock:^4"
+          env: DEPENDENCIES="dunglas/symfony-lock:^4" STABILITY="beta"
 
           # Latest commit to master
         - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,56 @@
-sudo: false
-
 language: php
-
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=2.3.*
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=2.7.*
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=2.8.*
-    - php: 7.0
-      env: SYMFONY_DI_VERSION=3.2.*
-
+sudo: false
 cache:
-  directories:
-    - ~/.composer/cache/files
+    directories:
+        - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
+env:
+    global:
+        - PHPUNIT_FLAGS="-v"
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+matrix:
+    fast_finish: true
+    include:
+          # Minimum supported Symfony version with the latest PHP version
+        - php: 7.1
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
+
+          # Test the latest stable release
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+          env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
+
+          # Force some major versions of Symfony
+        - php: 7.2
+          env: DEPENDENCIES="dunglas/symfony-lock:^2"
+        - php: 7.2
+          env: DEPENDENCIES="dunglas/symfony-lock:^3"
+        - php: 7.2
+          env: DEPENDENCIES="dunglas/symfony-lock:^4"
+
+          # Latest commit to master
+        - php: 7.2
+          env: STABILITY="dev"
+
+    allow_failures:
+          # Dev-master is allowed to fail.
+        - env: STABILITY="dev"
 
 before_install:
-  - phpenv config-rm xdebug.ini || true
-  - composer self-update
+    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
+    - if ! [ -z "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
 install:
-  - if [ ! -z ${SYMFONY_DI_VERSION+x} ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_DI_VERSION}"; fi
-  - composer install --prefer-dist
+    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+    - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
+    - vendor/bin/simple-phpunit install
 
-script: vendor/bin/phpunit
+script:
+    - composer validate --strict --no-check-lock
+    - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
 
 notifications:
   email: matthiasnoback@gmail.com
-
-cache:
-  directories:
-    - $COMPOSER_CACHE_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.0
+
+- Support for Symfony 4
+
 ## v2.1.0
 
 - Added support for validating invocation index order of method call (see #69).

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -78,16 +78,4 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
 
         new ContainerBuilderHasAliasConstraint('alias_id', new \stdClass());
     }
-
-    /**
-     * @test
-     */
-    public function it_lower_cases_aliased_service_ids()
-    {
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setAlias('foo', 'fooBar');
-        $constraint = new ContainerBuilderHasAliasConstraint('foo', 'fooBar');
-
-        $this->assertTrue($constraint->evaluate($containerBuilder, null, true));
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "require": {
         "php": "^7.0",
         "matthiasnoback/symfony-config-test": "^3.0",
-        "symfony/dependency-injection": "^2.3|^3.0",
-        "symfony/config": "^2.3|^3.0",
-        "symfony/yaml": "^2.7|^3.0"
+        "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
+        "symfony/config": "^2.7 || ^3.3 || ^4.0",
+        "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
This PR will replace #83 and fix #82 
It uses a travis file from (soon to be) symfony best practices. 

It ensures sf4 compatibility and does not give false positive as #83 does. (It downloads sf3 packages on the sf4 build)