### PR TITLE
Add return typehints to toString methods for compatibility with PHPUnit 7.0

### DIFF
--- a/PhpUnit/ContainerBuilderHasAliasConstraint.php
+++ b/PhpUnit/ContainerBuilderHasAliasConstraint.php
@@ -27,7 +27,7 @@ class ContainerBuilderHasAliasConstraint extends Constraint
         $this->expectedServiceId = $expectedServiceId;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'has an alias "' . $this->aliasId . '" for service "' . $this->expectedServiceId . '"';
     }

--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -29,7 +29,7 @@ class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
         $this->checkExpectedClass = $checkExpectedClass;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return sprintf(
             'has a service definition "%s" with class "%s"',

--- a/PhpUnit/ContainerBuilderHasSyntheticServiceConstraint.php
+++ b/PhpUnit/ContainerBuilderHasSyntheticServiceConstraint.php
@@ -20,7 +20,7 @@ class ContainerBuilderHasSyntheticServiceConstraint extends Constraint
         $this->serviceId = $serviceId;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return sprintf(
             'has a synthetic service "%s"',

--- a/PhpUnit/ContainerHasParameterConstraint.php
+++ b/PhpUnit/ContainerHasParameterConstraint.php
@@ -21,7 +21,7 @@ class ContainerHasParameterConstraint extends Constraint
         $this->checkParameterValue = $checkParameterValue;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return sprintf(
             'has a parameter "%s" with the given value',

--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -42,7 +42,7 @@ class DefinitionHasArgumentConstraint extends Constraint
         $this->checkExpectedValue = $checkExpectedValue;
     }
 
-    public function toString()
+    public function toString(): string
     {
         if (is_string($this->argumentIndex)) {
             return sprintf(

--- a/PhpUnit/DefinitionHasMethodCallConstraint.php
+++ b/PhpUnit/DefinitionHasMethodCallConstraint.php
@@ -66,7 +66,7 @@ class DefinitionHasMethodCallConstraint extends Constraint
         return false;
     }
 
-    public function toString()
+    public function toString(): string
     {
         if (null !== $this->index) {
             return sprintf(

--- a/PhpUnit/DefinitionHasTagConstraint.php
+++ b/PhpUnit/DefinitionHasTagConstraint.php
@@ -62,7 +62,7 @@ class DefinitionHasTagConstraint extends Constraint
         return false;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return sprintf(
             'has the "%s" tag with the given attributes',

--- a/PhpUnit/DefinitionIsChildOfConstraint.php
+++ b/PhpUnit/DefinitionIsChildOfConstraint.php
@@ -37,7 +37,7 @@ class DefinitionIsChildOfConstraint extends Constraint
         return true;
     }
 
-    public function toString()
+    public function toString(): string
     {
         return sprintf(
             'is a child of service "%s"',


### PR DESCRIPTION
Contravariance makes it possible for this to be compatible with both PHPUnit 6 with no return type hints.