### PR TITLE
Add constraints for ServiceLocator services

### DIFF
--- a/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
+{
+    /**
+     * @var int|string
+     */
+    private $argumentIndex;
+    private $expectedValue;
+    private $serviceId;
+
+    public function __construct($serviceId, $argumentIndex, array $expectedValue)
+    {
+        parent::__construct();
+
+        if (!(is_string($argumentIndex) || (is_int($argumentIndex) && $argumentIndex >= 0))) {
+            throw new \InvalidArgumentException('Expected either a string or a positive integer for $argumentIndex.');
+        }
+
+        if (is_string($argumentIndex)) {
+            if ('' === $argumentIndex) {
+                throw new \InvalidArgumentException('A named argument must begin with a "$".');
+            }
+
+            if ('$' !== $argumentIndex[0]) {
+                throw new \InvalidArgumentException(
+                    sprintf('Unknown argument "%s". Did you mean "$%s"?', $argumentIndex, $argumentIndex)
+                );
+            }
+        }
+
+        $this->serviceId = $serviceId;
+        $this->argumentIndex = $argumentIndex;
+        $this->expectedValue = array_map(
+            function ($serviceId) {
+                if (is_string($serviceId)) {
+                    return new ServiceClosureArgument(new Reference($serviceId));
+                }
+
+                if (!$serviceId instanceof ServiceClosureArgument) {
+                    return new ServiceClosureArgument($serviceId);
+                }
+
+                return $serviceId;
+            },
+            $expectedValue
+        );
+    }
+
+    public function toString(): string
+    {
+        if (is_string($this->argumentIndex)) {
+            return sprintf(
+                'has an argument named "%s" with the ServiceLocator',
+                $this->argumentIndex
+            );
+        }
+
+        return sprintf(
+            'has an argument with index %d with the ServiceLocator',
+            $this->argumentIndex
+        );
+    }
+
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        if (!($other instanceof ContainerBuilder)) {
+            throw new \InvalidArgumentException(
+                'Expected an instance of Symfony\Component\DependencyInjection\ContainerBuilder'
+            );
+        }
+
+        if (!$this->evaluateArgumentIndex($other->findDefinition($this->serviceId), $returnResult)) {
+            return false;
+        }
+
+        if (!$this->evaluateArgumentValue($other, $returnResult)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function evaluateArgumentIndex(Definition $definition, $returnResult)
+    {
+        try {
+            $definition->getArgument($this->argumentIndex);
+        } catch (\Exception $exception) {
+            // Older versions of Symfony throw \OutOfBoundsException
+            // Newer versions throw Symfony\Component\DependencyInjection\Exception\OutOfBoundsException
+            if (!($exception instanceof \OutOfBoundsException || $exception instanceof OutOfBoundsException)) {
+                // this was not the expected exception
+                throw $exception;
+            }
+
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail(
+                $definition,
+                sprintf('The definition has no argument with index %s', $this->argumentIndex)
+            );
+        }
+
+        return true;
+    }
+
+    private function evaluateArgumentValue(ContainerBuilder $container, $returnResult)
+    {
+        $definition = $container->findDefinition($this->serviceId);
+        $actualValue = $definition->getArgument($this->argumentIndex);
+        $serviceLocatorDef = $actualValue;
+
+        if ($actualValue instanceof Reference) {
+            $serviceLocatorDef = $container->findDefinition((string) $actualValue);
+        } elseif (!($actualValue instanceof Definition)) {
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail(
+                $definition,
+                sprintf(
+                    'The value of argument with index %s (%s) was expected to an instance of Symfony\Component\DependencyInjection\Reference or \Symfony\Component\DependencyInjection\Definition',
+                    $this->argumentIndex,
+                    $this->exporter->export($actualValue)
+                )
+            );
+        }
+
+        if (!is_a($serviceLocatorDef->getClass(), ServiceLocator::class, true)) {
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail(
+                $definition,
+                sprintf(
+                    'The referenced service class of argument with index %s (%s) was expected to be an instance of Symfony\Component\DependencyInjection\ServiceLocator',
+                    $this->argumentIndex,
+                    $this->exporter->export($serviceLocatorDef->getClass())
+                )
+            );
+        }
+
+        // Service locator was provided as context (and therefor a factory)
+        if (isset($serviceLocatorDef->getFactory()[1])) {
+            $serviceLocatorDef = $container->findDefinition((string) $serviceLocatorDef->getFactory()[0]);
+        }
+
+        return $this->evaluateServiceDefinition($serviceLocatorDef, $definition, $returnResult);
+    }
+
+    private function evaluateServiceDefinition(Definition $serviceLocatorDef, Definition $definition, $returnResult): bool
+    {
+        $actualValue = $serviceLocatorDef->getArgument(0);
+        $constraint = new IsEqual($this->expectedValue);
+
+        if (!$constraint->evaluate($actualValue, '', true)) {
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail(
+                $definition,
+                sprintf(
+                    'The value of argument with index %s (%s) does not equal to the expected ServiceLocator service-map (%s)',
+                    $this->argumentIndex,
+                    $this->exporter->export($actualValue),
+                    $this->exporter->export($this->expectedValue)
+                )
+            );
+        }
+
+        return true;
+    }
+}

--- a/PhpUnit/DefinitionEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionEqualsServiceLocatorConstraint.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+class DefinitionEqualsServiceLocatorConstraint extends Constraint
+{
+    private $expectedValue;
+
+    public function __construct($expectedValue)
+    {
+        parent::__construct();
+
+        $this->expectedValue = array_map(
+            function ($serviceId) {
+                if (is_string($serviceId)) {
+                    return new ServiceClosureArgument(new Reference($serviceId));
+                }
+
+                if (!$serviceId instanceof ServiceClosureArgument) {
+                    return new ServiceClosureArgument($serviceId);
+                }
+
+                return $serviceId;
+            },
+            $expectedValue
+        );
+    }
+
+    public function toString(): string
+    {
+        return sprintf('service definition is a service locator');
+    }
+
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        if (!($other instanceof Definition)) {
+            throw new \InvalidArgumentException(
+                'Expected an instance of Symfony\Component\DependencyInjection\Definition'
+            );
+        }
+
+        return $this->evaluateServiceDefinition($other, $returnResult);
+    }
+
+    private function evaluateServiceDefinition(Definition $definition, $returnResult)
+    {
+        if (!$this->evaluateServiceDefinitionClass($definition, $returnResult)) {
+            return false;
+        }
+
+        return $this->evaluateArgumentIndex($definition, $returnResult);
+    }
+
+    private function evaluateServiceDefinitionClass(Definition $definition, $returnResult)
+    {
+        if (is_a($definition->getClass(), ServiceLocator::class, true)) {
+            return true;
+        }
+
+        if ($returnResult) {
+            return false;
+        }
+
+        $this->fail(
+            $definition,
+            sprintf(
+                'class %s was expected as service definition class, found %s instead',
+                $this->exporter->export(ServiceLocator::class),
+                $this->exporter->export($definition->getClass())
+            )
+        );
+    }
+
+    private function evaluateArgumentIndex(Definition $definition, $returnResult)
+    {
+        $actualValue = $definition->getArgument(0);
+        $constraint = new IsEqual($this->expectedValue);
+
+        if (!$constraint->evaluate($actualValue, '', true)) {
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail(
+                $definition,
+                sprintf(
+                    'The service-map %s does not equal to the expected service-map (%s)',
+                    $this->exporter->export($actualValue),
+                    $this->exporter->export($this->expectedValue)
+                )
+            );
+        }
+
+        return true;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ the given index.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithArgument($serviceId, $argumentIndex, $expectedValue)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has an argument at
 the given index, and its value is the given value.</dd>
+<dt><code>assertContainerBuilderHasServiceDefinitionWithServiceLocatorArgument($serviceId, $argumentIndex, $expectedValue)</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has an argument
+at the given index, and its value is a ServiceLocator with a reference-map equal to the given value.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithMethodCall($serviceId, $method, array $arguments = array(), $index = null)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has a method call to
 the given method with the given arguments. If index is provided, invocation index order of method call is asserted as well.</dd>
@@ -318,6 +321,8 @@ the given method with the given arguments. If index is provided, invocation inde
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has the given tag with the given arguments.</dd>
 <dt><code>assertContainerBuilderHasServiceDefinitionWithParent($serviceId, $parentServiceId)</code></dt>
 <dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id which is a decorated service and it has the given parent service.</dd>
+<dt><code>assertContainerBuilderHasServiceLocator($serviceId, $expectedServiceMap)</code></dt>
+<dd>Assert that the <code>ContainerBuilder</code> for this test has a ServiceLocator service definition with the given id.</dd>
 </dl>
 
 ## Available methods to set up container

--- a/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionArgumentEqualsServiceLocatorConstraint;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $containerBuilder;
+
+    protected function setUp()
+    {
+        if (!class_exists(ServiceLocator::class)) {
+            $this->markTestSkipped('Requires the Symfony DependencyInjection component v3.4 or higher');
+        }
+
+        $this->containerBuilder = new ContainerBuilder();
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_if_the_service_definition_is_not_a_service_locator()
+    {
+        $this->containerBuilder->setDefinition('not_a_service_locator', new Definition());
+        $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [new Reference('not_a_service_locator')]));
+
+        $this->assertConstraintFails(new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', 0, []));
+    }
+
+    /**
+     * @test
+     */
+    public function if_fails_if_the_service_definition_value_references_a_missing_service()
+    {
+        $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [new Reference('not_a_service_locator')]));
+
+        $this->expectException(ServiceNotFoundException::class);
+
+        $this->assertConstraintFails(new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', 0, []));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideInvalidServiceLocatorReferences
+     */
+    public function if_fails_if_the_service_definition_value_is_not_a_valid_reference($arguments)
+    {
+        $this->containerBuilder->setDefinition('service_locator', new Definition(ServiceLocator::class, $arguments));
+        $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [new Reference('service_locator')]));
+
+        $this->assertConstraintFails(new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', 0, [new Reference('foo')]));
+    }
+
+    public function provideInvalidServiceLocatorReferences()
+    {
+        yield [['']];
+        yield [[null]];
+        yield [[null, null]];
+        yield [[new Reference('foo'), null]];
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator()
+    {
+        $definition = new Definition(ServiceLocator::class, [['bar' => new ServiceClosureArgument(new Reference('foo'))]]);
+        $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [null, '$l' => $definition]));
+
+        $this->assertConstraintPasses(new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', '$l', ['bar' => new Reference('foo')]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator_reference()
+    {
+        $id = ServiceLocatorTagPass::register($this->containerBuilder, ['bar' => new Reference('foo')]);
+        $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [$id]));
+
+        $this->assertConstraintPasses(
+            new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', 0, ['bar' => new Reference('foo')])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator_with_a_with_a_context()
+    {
+        $id = ServiceLocatorTagPass::register($this->containerBuilder, ['bar' => new Reference('foo')], 'using_service');
+        $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [$id]));
+
+        $this->assertConstraintPasses(
+            new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', 0, ['bar' => new Reference('foo')])
+        );
+    }
+
+    private function assertConstraintFails(Constraint $constraint)
+    {
+        $this->assertFalse($constraint->evaluate($this->containerBuilder, '', true));
+    }
+
+    private function assertConstraintPasses(Constraint $constraint)
+    {
+        $this->assertTrue($constraint->evaluate($this->containerBuilder, '', false));
+    }
+}

--- a/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
+++ b/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionEqualsServiceLocatorConstraint;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class DefinitionEqualsServiceLocatorTest extends TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $containerBuilder;
+
+    protected function setUp()
+    {
+        if (!class_exists(ServiceLocator::class)) {
+            $this->markTestSkipped('Requires the Symfony DependencyInjection component v3.4 or higher');
+        }
+
+        $this->containerBuilder = new ContainerBuilder();
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_if_the_service_definition_is_not_a_service_locator()
+    {
+        $this->assertConstraintFails(new DefinitionEqualsServiceLocatorConstraint([]), new Definition());
+        $this->assertConstraintFails(new DefinitionEqualsServiceLocatorConstraint([]), new Definition(\stdClass::class));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideInvalidServiceLocatorReferences
+     */
+    public function if_fails_if_the_service_definition_value_is_not_a_valid_reference($arguments)
+    {
+        $this->assertConstraintFails(
+            new DefinitionEqualsServiceLocatorConstraint([]),
+            new Definition(ServiceLocator::class, $arguments)
+        );
+    }
+
+    public function provideInvalidServiceLocatorReferences()
+    {
+        yield [['']];
+        yield [[null]];
+        yield [[null, null]];
+        yield [[new Reference('foo'), null]];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideValidServiceLocatorDefs
+     */
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator(array $defArguments, array $expected)
+    {
+        $this->assertConstraintPasses(
+            new DefinitionEqualsServiceLocatorConstraint($expected),
+            new Definition(ServiceLocator::class, [$defArguments])
+        );
+    }
+
+    public function provideValidServiceLocatorDefs()
+    {
+        // Data providers get called before setUp?
+        if (!class_exists(ServiceLocator::class)) {
+            return [[], []];
+        }
+
+        yield [
+            ['bar' => new ServiceClosureArgument(new Reference('foo'))],
+            ['bar' => new Reference('foo')],
+        ];
+
+        yield [
+            ['bar' => new ServiceClosureArgument(new Reference('foo'))],
+            ['bar' => new ServiceClosureArgument(new Reference('foo'))],
+        ];
+
+        yield [
+            ['bar' => new ServiceClosureArgument(new Reference('foo'))],
+            ['bar' => 'foo'],
+        ];
+
+        yield [
+            [
+                'bar' => new ServiceClosureArgument(new Reference('foo')),
+                'foo' => new ServiceClosureArgument(new Reference('bar')),
+            ],
+            ['bar' => 'foo', 'foo' => 'bar'],
+        ];
+    }
+
+    private function assertConstraintFails(Constraint $constraint, $value)
+    {
+        $this->assertFalse($constraint->evaluate($value, '', true));
+    }
+
+    private function assertConstraintPasses(Constraint $constraint, $value)
+    {
+        $this->assertTrue($constraint->evaluate($value, '', true));
+    }
+}


### PR DESCRIPTION
This adds two new assertion constraints for the Symfony ServiceLocator.

<dl>
<dt><code>assertContainerBuilderHasServiceDefinitionWithServiceLocatorArgument($serviceId, $argumentIndex, $expectedValue)</code></dt>
<dd>Assert that the <code>ContainerBuilder</code> for this test has a service definition with the given id, which has an argument
at the given index, and its value is a ServiceLocator with a reference-map equal to the given value.</dd>
<dt><code>assertContainerBuilderHasServiceLocator($serviceId, $expectedServiceMap)</code></dt>
<dd>Assert that the <code>ContainerBuilder</code> for this test has a ServiceLocator service definition with the given id.</dd>
</dl>

I tried to follow the CS and descriptions as much as the existing one, if there is anything missing please let me know.