### PR TITLE
Drop old sf and add type hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
 
           # Force some major versions of Symfony
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^2"
-        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
         - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^4"

--- a/Loader/ExtensionConfigurationBuilder.php
+++ b/Loader/ExtensionConfigurationBuilder.php
@@ -23,7 +23,7 @@ class ExtensionConfigurationBuilder
         return $this;
     }
 
-    public function getExtension()
+    public function getExtension(): ExtensionInterface
     {
         if (!($this->extension instanceof ExtensionInterface)) {
             throw new \LogicException('You need to call setExtension() first');
@@ -46,7 +46,7 @@ class ExtensionConfigurationBuilder
         return $this;
     }
 
-    public function getSources()
+    public function getSources(): array
     {
         if (count($this->sources) === 0) {
             throw new \LogicException('You need to call setSources() or addSource() first');
@@ -55,7 +55,7 @@ class ExtensionConfigurationBuilder
         return $this->sources;
     }
 
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         $container = new ContainerBuilder();
 
@@ -66,7 +66,7 @@ class ExtensionConfigurationBuilder
         return $this->getExtensionConfiguration($container);
     }
 
-    private function loadSources(ContainerBuilder $container, array $sources)
+    private function loadSources(ContainerBuilder $container, array $sources): void
     {
         foreach ($sources as $source) {
             $loader = $this->loaderFactory->createLoaderForSource($container, $source);
@@ -74,7 +74,7 @@ class ExtensionConfigurationBuilder
         }
     }
 
-    private function getExtensionConfiguration(ContainerBuilder $container)
+    private function getExtensionConfiguration(ContainerBuilder $container): array
     {
         $extensionAlias = $this->getExtension()->getAlias();
 

--- a/Loader/LoaderFactory.php
+++ b/Loader/LoaderFactory.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\Loader;
 
 use Matthias\SymfonyDependencyInjectionTest\Loader\Exception\UnknownConfigurationSourceException;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
@@ -13,7 +14,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class LoaderFactory implements LoaderFactoryInterface
 {
-    public function createLoaderForSource(ContainerBuilder $container, $source)
+    public function createLoaderForSource(ContainerBuilder $container, $source): LoaderInterface
     {
         if ($source instanceof \Closure) {
             return new ClosureLoader($container);
@@ -41,22 +42,22 @@ class LoaderFactory implements LoaderFactoryInterface
         ));
     }
 
-    public function createYamlFileLoader($container)
+    public function createYamlFileLoader($container): YamlFileLoader
     {
         return new YamlFileLoader($container, new FileLocator());
     }
 
-    public function createXmlFileLoader(ContainerBuilder $container)
+    public function createXmlFileLoader(ContainerBuilder $container): XmlFileLoader
     {
         return new XmlFileLoader($container, new FileLocator());
     }
 
-    public function createPhpFileLoader(ContainerBuilder $container)
+    public function createPhpFileLoader(ContainerBuilder $container): PhpFileLoader
     {
         return new PhpFileLoader($container, new FileLocator());
     }
 
-    public function createIniFileLoader(ContainerBuilder $container)
+    public function createIniFileLoader(ContainerBuilder $container): IniFileLoader
     {
         return new IniFileLoader($container, new FileLocator());
     }

--- a/Loader/LoaderFactoryInterface.php
+++ b/Loader/LoaderFactoryInterface.php
@@ -7,11 +7,5 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 interface LoaderFactoryInterface
 {
-    /**
-     * @param ContainerBuilder $container
-     * @param $source
-     *
-     * @return LoaderInterface
-     */
-    public function createLoaderForSource(ContainerBuilder $container, $source);
+    public function createLoaderForSource(ContainerBuilder $container, $source): LoaderInterface;
 }

--- a/PhpUnit/AbstractCompilerPassTestCase.php
+++ b/PhpUnit/AbstractCompilerPassTestCase.php
@@ -12,14 +12,14 @@ abstract class AbstractCompilerPassTestCase extends AbstractContainerBuilderTest
      *
      *   $container->addCompilerPass(new MyCompilerPass());
      */
-    abstract protected function registerCompilerPass(ContainerBuilder $container);
+    abstract protected function registerCompilerPass(ContainerBuilder $container): void;
 
     /**
      * This test will run the compile method.
      *
      * @test
      */
-    public function compilation_should_not_fail_with_empty_container()
+    public function compilation_should_not_fail_with_empty_container(): void
     {
         try {
             $this->compile();

--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -29,13 +29,8 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
 
     /**
      * Shortcut for quickly defining services. The returned Definition object can be further modified if necessary.
-     *
-     * @param $serviceId
-     * @param $class
-     *
-     * @return Definition
      */
-    protected function registerService($serviceId, $class)
+    protected function registerService(string $serviceId, string $class): Definition
     {
         $definition = new Definition($class);
 
@@ -46,11 +41,8 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
 
     /**
      * Set a service definition you manually created.
-     *
-     * @param $serviceId
-     * @param Definition $definition
      */
-    protected function setDefinition($serviceId, Definition $definition)
+    protected function setDefinition(string $serviceId, Definition $definition): void
     {
         $this->container->setDefinition($serviceId, $definition);
     }
@@ -58,10 +50,9 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     /**
      * Set a parameter.
      *
-     * @param $parameterId
-     * @param $parameterValue
+     * @param mixed $parameterValue
      */
-    protected function setParameter($parameterId, $parameterValue)
+    protected function setParameter(string $parameterId, $parameterValue): void
     {
         $this->container->setParameter($parameterId, $parameterValue);
     }
@@ -69,18 +60,15 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     /**
      * Call this method to compile the ContainerBuilder, to test if any problems would occur at runtime.
      */
-    protected function compile()
+    protected function compile(): void
     {
         $this->container->compile();
     }
 
     /**
      * Assert that the ContainerBuilder for this test has a service definition with the given id and class.
-     *
-     * @param $serviceId
-     * @param $expectedClass
      */
-    protected function assertContainerBuilderHasService($serviceId, $expectedClass = null)
+    protected function assertContainerBuilderHasService(string $serviceId, ?string $expectedClass = null): void
     {
         $checkExpectedClass = (func_num_args() > 1);
 
@@ -92,10 +80,8 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
 
     /**
      * Assert that the ContainerBuilder for this test does not have a service definition with the given id.
-     *
-     * @param $serviceId
      */
-    protected function assertContainerBuilderNotHasService($serviceId)
+    protected function assertContainerBuilderNotHasService(string $serviceId): void
     {
         self::assertThat(
             $this->container,
@@ -105,10 +91,8 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
 
     /**
      * Assert that the ContainerBuilder for this test has a synthetic service with the given id.
-     *
-     * @param $serviceId
      */
-    protected function assertContainerBuilderHasSyntheticService($serviceId)
+    protected function assertContainerBuilderHasSyntheticService(string $serviceId): void
     {
         self::assertThat(
             $this->container,
@@ -118,11 +102,8 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
 
     /**
      * Assert that the ContainerBuilder for this test has an alias and that it is an alias for the given service id.
-     *
-     * @param $aliasId
-     * @param $expectedServiceId
      */
-    protected function assertContainerBuilderHasAlias($aliasId, $expectedServiceId = null)
+    protected function assertContainerBuilderHasAlias(string $aliasId, ?string $expectedServiceId = null): void
     {
         self::assertThat(
             $this->container,
@@ -133,10 +114,9 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     /**
      * Assert that the ContainerBuilder for this test has a parameter and that its value is the given value.
      *
-     * @param $parameterName
-     * @param $expectedParameterValue
+     * @param mixed $expectedParameterValue
      */
-    protected function assertContainerBuilderHasParameter($parameterName, $expectedParameterValue = null)
+    protected function assertContainerBuilderHasParameter(string $parameterName, $expectedParameterValue = null): void
     {
         $checkParameterValue = (func_num_args() > 1);
 
@@ -150,15 +130,13 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
      * Assert that the ContainerBuilder for this test has a service definition with the given id, which has an argument
      * at the given index, and its value is the given value.
      *
-     * @param $serviceId
-     * @param $argumentIndex
-     * @param $expectedValue
+     * @param mixed $expectedValue
      */
     protected function assertContainerBuilderHasServiceDefinitionWithArgument(
-        $serviceId,
+        string $serviceId,
         $argumentIndex,
         $expectedValue = null
-    ) {
+    ): void {
         $definition = $this->container->findDefinition($serviceId);
         $checkValue = (func_num_args() > 2);
 
@@ -172,15 +150,14 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
      * Assert that the ContainerBuilder for this test has a service definition with the given id, which has an argument
      * at the given index, and its value is a ServiceLocator with a reference-map equal to the given value.
      *
-     * @param string     $serviceId
      * @param int|string $argumentIndex
      * @param array      $expectedServiceMap an array of service-id references and their key in the map
      */
     protected function assertContainerBuilderHasServiceDefinitionWithServiceLocatorArgument(
-        $serviceId,
+        string $serviceId,
         $argumentIndex,
         array $expectedValue
-    ) {
+    ): void {
         self::assertThat(
             $this->container,
             new DefinitionArgumentEqualsServiceLocatorConstraint($serviceId, $argumentIndex, $expectedValue)
@@ -191,17 +168,14 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
      * Assert that the ContainerBuilder for this test has a service definition with the given id, which has a method
      * call to the given method with the given arguments.
      *
-     * @param string   $serviceId
-     * @param string   $method
-     * @param array    $arguments
      * @param int|null $index
      */
     protected function assertContainerBuilderHasServiceDefinitionWithMethodCall(
-        $serviceId,
-        $method,
+        string $serviceId,
+        string $method,
         array $arguments = [],
         $index = null
-    ) {
+    ): void {
         $definition = $this->container->findDefinition($serviceId);
 
         self::assertThat($definition, new DefinitionHasMethodCallConstraint($method, $arguments, $index));
@@ -210,16 +184,12 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     /**
      * Assert that the ContainerBuilder for this test has a service definition with the given id, which has a tag
      * with the given attributes.
-     *
-     * @param string $serviceId
-     * @param string $tag
-     * @param array  $attributes
      */
     protected function assertContainerBuilderHasServiceDefinitionWithTag(
-        $serviceId,
-        $tag,
+        string $serviceId,
+        string $tag,
         array $attributes = []
-    ) {
+    ): void {
         $definition = $this->container->findDefinition($serviceId);
 
         self::assertThat($definition, new DefinitionHasTagConstraint($tag, $attributes));
@@ -228,11 +198,8 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     /**
      * Assert that the ContainerBuilder for this test has a service definition with the given id which is a decorated
      * service and it has the given parent service.
-     *
-     * @param $serviceId
-     * @param $parentServiceId
      */
-    protected function assertContainerBuilderHasServiceDefinitionWithParent($serviceId, $parentServiceId)
+    protected function assertContainerBuilderHasServiceDefinitionWithParent(string $serviceId, string $parentServiceId): void
     {
         $definition = $this->container->findDefinition($serviceId);
 
@@ -242,10 +209,9 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     /**
      * Assert that the ContainerBuilder for this test has a ServiceLocator service definition with the given id.
      *
-     * @param string $serviceId
-     * @param array  $expectedServiceMap an array of service-id references and their key in the map
+     * @param array $expectedServiceMap an array of service-id references and their key in the map
      */
-    protected function assertContainerBuilderHasServiceLocator(string $serviceId, array $expectedServiceMap = [])
+    protected function assertContainerBuilderHasServiceLocator(string $serviceId, array $expectedServiceMap = []): void
     {
         $definition = $this->container->findDefinition($serviceId);
 

--- a/PhpUnit/AbstractExtensionConfigurationTestCase.php
+++ b/PhpUnit/AbstractExtensionConfigurationTestCase.php
@@ -13,19 +13,15 @@ abstract class AbstractExtensionConfigurationTestCase extends TestCase
 {
     /**
      * Return an instance of the container extension that you are testing.
-     *
-     * @return ExtensionInterface
      */
-    abstract protected function getContainerExtension();
+    abstract protected function getContainerExtension(): ExtensionInterface;
 
     /**
      * Return an instance of the configuration class that you are testing.
-     *
-     * @return ConfigurationInterface
      */
-    abstract protected function getConfiguration();
+    abstract protected function getConfiguration(): ConfigurationInterface;
 
-    protected function assertProcessedConfigurationEquals($expectedConfiguration, array $sources)
+    protected function assertProcessedConfigurationEquals(array $expectedConfiguration, array $sources): void
     {
         $extensionConfigurationBuilder = new ExtensionConfigurationBuilder(new LoaderFactory());
         $extensionConfiguration = $extensionConfigurationBuilder

--- a/PhpUnit/AbstractExtensionTestCase.php
+++ b/PhpUnit/AbstractExtensionTestCase.php
@@ -13,14 +13,14 @@ abstract class AbstractExtensionTestCase extends AbstractContainerBuilderTestCas
      *
      * @return ExtensionInterface[]
      */
-    abstract protected function getContainerExtensions();
+    abstract protected function getContainerExtensions(): array;
 
     /**
      * Optionally override this method to return an array that will be used as the minimal configuration for loading
      * the container extension under test, to prevent a test from failing because of a missing required
      * configuration value for the container extension.
      */
-    protected function getMinimalConfiguration()
+    protected function getMinimalConfiguration(): array
     {
         return [];
     }
@@ -44,10 +44,8 @@ abstract class AbstractExtensionTestCase extends AbstractContainerBuilderTestCas
     /**
      * Call this method from within your test after you have (optionally) modified the ContainerBuilder for this test
      * ($this->container).
-     *
-     * @param array $configurationValues
      */
-    protected function load(array $configurationValues = [])
+    protected function load(array $configurationValues = []): void
     {
         $configs = [$this->getMinimalConfiguration(), $configurationValues];
 
@@ -63,7 +61,7 @@ abstract class AbstractExtensionTestCase extends AbstractContainerBuilderTestCas
     /**
      * Call this method if you want to compile the ContainerBuilder *inside* the test instead of *after* the test.
      */
-    protected function compile()
+    protected function compile(): void
     {
         $this->container->compile();
     }

--- a/PhpUnit/ContainerBuilderHasAliasConstraint.php
+++ b/PhpUnit/ContainerBuilderHasAliasConstraint.php
@@ -22,7 +22,7 @@ class ContainerBuilderHasAliasConstraint extends Constraint
         return 'has an alias "'.$this->aliasId.'" for service "'.$this->expectedServiceId.'"';
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof ContainerBuilder)) {
             throw new \InvalidArgumentException(
@@ -41,7 +41,7 @@ class ContainerBuilderHasAliasConstraint extends Constraint
         return true;
     }
 
-    private function evaluateAliasId(ContainerBuilder $containerBuilder, $returnResult)
+    private function evaluateAliasId(ContainerBuilder $containerBuilder, bool $returnResult): bool
     {
         if (!$containerBuilder->hasAlias($this->aliasId)) {
             if ($returnResult) {
@@ -60,7 +60,7 @@ class ContainerBuilderHasAliasConstraint extends Constraint
         return true;
     }
 
-    private function evaluateServiceId(ContainerBuilder $containerBuilder, $returnResult)
+    private function evaluateServiceId(ContainerBuilder $containerBuilder, $returnResult): bool
     {
         $alias = $containerBuilder->getAlias($this->aliasId);
 

--- a/PhpUnit/ContainerBuilderHasAliasConstraint.php
+++ b/PhpUnit/ContainerBuilderHasAliasConstraint.php
@@ -11,16 +11,8 @@ class ContainerBuilderHasAliasConstraint extends Constraint
     private $aliasId;
     private $expectedServiceId;
 
-    public function __construct($aliasId, $expectedServiceId = null)
+    public function __construct(string $aliasId, ?string $expectedServiceId = null)
     {
-        if (!is_string($aliasId)) {
-            throw new \InvalidArgumentException('The $aliasId argument should be a string');
-        }
-
-        if ($expectedServiceId !== null && !is_string($expectedServiceId)) {
-            throw new \InvalidArgumentException('The $expectedServiceId argument should be a string');
-        }
-
         $this->aliasId = $aliasId;
         $this->expectedServiceId = $expectedServiceId;
     }

--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -15,7 +15,7 @@ class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
     public function __construct(
         string $serviceId,
         ?string $expectedClass = null,
-        $checkExpectedClass = true
+        bool $checkExpectedClass = true
     ) {
         $this->serviceId = $serviceId;
         $this->expectedClass = $expectedClass;

--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -31,7 +31,7 @@ class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
         );
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof ContainerBuilder)) {
             throw new \InvalidArgumentException(
@@ -50,7 +50,7 @@ class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
         return true;
     }
 
-    private function evaluateServiceDefinition(ContainerBuilder $containerBuilder, $returnResult)
+    private function evaluateServiceDefinition(ContainerBuilder $containerBuilder, bool $returnResult): bool
     {
         if (!$containerBuilder->has($this->serviceId)) {
             if ($returnResult) {
@@ -69,7 +69,7 @@ class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
         return true;
     }
 
-    private function evaluateClass(ContainerBuilder $containerBuilder, $returnResult)
+    private function evaluateClass(ContainerBuilder $containerBuilder, bool $returnResult): bool
     {
         $definition = $containerBuilder->findDefinition($this->serviceId);
 

--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -12,16 +12,11 @@ class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
     private $expectedClass;
     private $checkExpectedClass;
 
-    public function __construct($serviceId, $expectedClass = null, $checkExpectedClass = true)
-    {
-        if (!is_string($serviceId)) {
-            throw new \InvalidArgumentException('The $serviceId argument should be a string');
-        }
-
-        if ($checkExpectedClass && !is_string($expectedClass)) {
-            throw new \InvalidArgumentException('The $expectedClass argument should be a string');
-        }
-
+    public function __construct(
+        string $serviceId,
+        ?string $expectedClass = null,
+        $checkExpectedClass = true
+    ) {
         $this->serviceId = $serviceId;
         $this->expectedClass = $expectedClass;
         $this->checkExpectedClass = $checkExpectedClass;

--- a/PhpUnit/ContainerBuilderHasSyntheticServiceConstraint.php
+++ b/PhpUnit/ContainerBuilderHasSyntheticServiceConstraint.php
@@ -22,7 +22,7 @@ class ContainerBuilderHasSyntheticServiceConstraint extends Constraint
         );
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof ContainerBuilder)) {
             throw new \InvalidArgumentException(
@@ -37,7 +37,7 @@ class ContainerBuilderHasSyntheticServiceConstraint extends Constraint
         return true;
     }
 
-    private function evaluateServiceDefinition(ContainerBuilder $containerBuilder, $returnResult)
+    private function evaluateServiceDefinition(ContainerBuilder $containerBuilder, bool $returnResult): bool
     {
         if (!$containerBuilder->has($this->serviceId)) {
             if ($returnResult) {

--- a/PhpUnit/ContainerBuilderHasSyntheticServiceConstraint.php
+++ b/PhpUnit/ContainerBuilderHasSyntheticServiceConstraint.php
@@ -9,12 +9,8 @@ class ContainerBuilderHasSyntheticServiceConstraint extends Constraint
 {
     private $serviceId;
 
-    public function __construct($serviceId)
+    public function __construct(string $serviceId)
     {
-        if (!is_string($serviceId)) {
-            throw new \InvalidArgumentException('The $serviceId argument should be a string');
-        }
-
         $this->serviceId = $serviceId;
     }
 

--- a/PhpUnit/ContainerHasParameterConstraint.php
+++ b/PhpUnit/ContainerHasParameterConstraint.php
@@ -12,8 +12,11 @@ class ContainerHasParameterConstraint extends Constraint
     private $expectedParameterValue;
     private $checkParameterValue;
 
-    public function __construct($parameterName, $expectedParameterValue = null, $checkParameterValue = false)
-    {
+    public function __construct(
+        string $parameterName,
+        $expectedParameterValue = null,
+        bool $checkParameterValue = false
+    ) {
         $this->parameterName = $parameterName;
         $this->expectedParameterValue = $expectedParameterValue;
         $this->checkParameterValue = $checkParameterValue;
@@ -27,7 +30,7 @@ class ContainerHasParameterConstraint extends Constraint
         );
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof ContainerInterface)) {
             throw new \InvalidArgumentException(
@@ -46,7 +49,7 @@ class ContainerHasParameterConstraint extends Constraint
         return true;
     }
 
-    private function evaluateParameterName(ContainerInterface $container, $returnResult)
+    private function evaluateParameterName(ContainerInterface $container, bool $returnResult): bool
     {
         if (!$container->hasParameter($this->parameterName)) {
             if ($returnResult) {
@@ -62,7 +65,7 @@ class ContainerHasParameterConstraint extends Constraint
         return true;
     }
 
-    private function evaluateParameterValue(ContainerInterface $container, $returnResult)
+    private function evaluateParameterValue(ContainerInterface $container, bool $returnResult): bool
     {
         $actualValue = $container->getParameter($this->parameterName);
 

--- a/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
@@ -94,14 +94,7 @@ class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
     {
         try {
             $definition->getArgument($this->argumentIndex);
-        } catch (\Exception $exception) {
-            // Older versions of Symfony throw \OutOfBoundsException
-            // Newer versions throw Symfony\Component\DependencyInjection\Exception\OutOfBoundsException
-            if (!($exception instanceof \OutOfBoundsException || $exception instanceof OutOfBoundsException)) {
-                // this was not the expected exception
-                throw $exception;
-            }
-
+        } catch (OutOfBoundsException $exception) {
             if ($returnResult) {
                 return false;
             }

--- a/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
@@ -20,7 +20,7 @@ class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
     private $expectedValue;
     private $serviceId;
 
-    public function __construct($serviceId, $argumentIndex, array $expectedValue)
+    public function __construct(string $serviceId, $argumentIndex, array $expectedValue)
     {
         if (!(is_string($argumentIndex) || (is_int($argumentIndex) && $argumentIndex >= 0))) {
             throw new \InvalidArgumentException('Expected either a string or a positive integer for $argumentIndex.');
@@ -71,7 +71,7 @@ class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
         );
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof ContainerBuilder)) {
             throw new \InvalidArgumentException(
@@ -90,7 +90,7 @@ class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
         return true;
     }
 
-    private function evaluateArgumentIndex(Definition $definition, $returnResult)
+    private function evaluateArgumentIndex(Definition $definition, bool $returnResult): bool
     {
         try {
             $definition->getArgument($this->argumentIndex);
@@ -108,7 +108,7 @@ class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
         return true;
     }
 
-    private function evaluateArgumentValue(ContainerBuilder $container, $returnResult)
+    private function evaluateArgumentValue(ContainerBuilder $container, bool $returnResult): bool
     {
         $definition = $container->findDefinition($this->serviceId);
         $actualValue = $definition->getArgument($this->argumentIndex);
@@ -154,8 +154,11 @@ class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
         return $this->evaluateServiceDefinition($serviceLocatorDef, $definition, $returnResult);
     }
 
-    private function evaluateServiceDefinition(Definition $serviceLocatorDef, Definition $definition, $returnResult): bool
-    {
+    private function evaluateServiceDefinition(
+        Definition $serviceLocatorDef,
+        Definition $definition,
+        bool $returnResult
+    ): bool {
         $actualValue = $serviceLocatorDef->getArgument(0);
         $constraint = new IsEqual($this->expectedValue);
 

--- a/PhpUnit/DefinitionEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionEqualsServiceLocatorConstraint.php
@@ -36,7 +36,7 @@ class DefinitionEqualsServiceLocatorConstraint extends Constraint
         return sprintf('service definition is a service locator');
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof Definition)) {
             throw new \InvalidArgumentException(
@@ -47,7 +47,7 @@ class DefinitionEqualsServiceLocatorConstraint extends Constraint
         return $this->evaluateServiceDefinition($other, $returnResult);
     }
 
-    private function evaluateServiceDefinition(Definition $definition, $returnResult)
+    private function evaluateServiceDefinition(Definition $definition, bool $returnResult): bool
     {
         if (!$this->evaluateServiceDefinitionClass($definition, $returnResult)) {
             return false;
@@ -56,7 +56,7 @@ class DefinitionEqualsServiceLocatorConstraint extends Constraint
         return $this->evaluateArgumentIndex($definition, $returnResult);
     }
 
-    private function evaluateServiceDefinitionClass(Definition $definition, $returnResult)
+    private function evaluateServiceDefinitionClass(Definition $definition, bool $returnResult): bool
     {
         if (is_a($definition->getClass(), ServiceLocator::class, true)) {
             return true;
@@ -76,7 +76,7 @@ class DefinitionEqualsServiceLocatorConstraint extends Constraint
         );
     }
 
-    private function evaluateArgumentIndex(Definition $definition, $returnResult)
+    private function evaluateArgumentIndex(Definition $definition, bool $returnResult): bool
     {
         $actualValue = $definition->getArgument(0);
         $constraint = new IsEqual($this->expectedValue);

--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -16,7 +16,7 @@ class DefinitionHasArgumentConstraint extends Constraint
     private $expectedValue;
     private $checkExpectedValue;
 
-    public function __construct($argumentIndex, $expectedValue, $checkExpectedValue = true)
+    public function __construct($argumentIndex, $expectedValue, bool $checkExpectedValue = true)
     {
         if (!(is_string($argumentIndex) || (is_int($argumentIndex) && $argumentIndex >= 0))) {
             throw new \InvalidArgumentException('Expected either a string or a positive integer for $argumentIndex.');
@@ -54,7 +54,7 @@ class DefinitionHasArgumentConstraint extends Constraint
         );
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof Definition)) {
             throw new \InvalidArgumentException(
@@ -73,7 +73,7 @@ class DefinitionHasArgumentConstraint extends Constraint
         return true;
     }
 
-    private function evaluateArgumentIndex(Definition $definition, $returnResult)
+    private function evaluateArgumentIndex(Definition $definition, bool $returnResult): bool
     {
         try {
             $definition->getArgument($this->argumentIndex);
@@ -94,7 +94,7 @@ class DefinitionHasArgumentConstraint extends Constraint
         return true;
     }
 
-    private function evaluateArgumentValue(Definition $definition, $returnResult)
+    private function evaluateArgumentValue(Definition $definition, bool $returnResult): bool
     {
         $actualValue = $definition->getArgument($this->argumentIndex);
 

--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -77,14 +77,7 @@ class DefinitionHasArgumentConstraint extends Constraint
     {
         try {
             $definition->getArgument($this->argumentIndex);
-        } catch (\Exception $exception) {
-            // Older versions of Symfony throw \OutOfBoundsException
-            // Newer versions throw Symfony\Component\DependencyInjection\Exception\OutOfBoundsException
-            if (!($exception instanceof \OutOfBoundsException || $exception instanceof OutOfBoundsException)) {
-                // this was not the expected exception
-                throw $exception;
-            }
-
+        } catch (OutOfBoundsException $exception) {
             if ($returnResult) {
                 return false;
             }

--- a/PhpUnit/DefinitionHasMethodCallConstraint.php
+++ b/PhpUnit/DefinitionHasMethodCallConstraint.php
@@ -12,7 +12,7 @@ class DefinitionHasMethodCallConstraint extends Constraint
     private $arguments;
     private $index;
 
-    public function __construct($methodName, array $arguments = [], $index = null)
+    public function __construct(string $methodName, array $arguments = [], $index = null)
     {
         if ($index !== null && !is_int($index)) {
             throw new \InvalidArgumentException(sprintf('Expected value of integer type for method call index, "%s" given.', is_object($index) ? get_class($index) : gettype($index)));
@@ -23,7 +23,7 @@ class DefinitionHasMethodCallConstraint extends Constraint
         $this->index = $index;
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof Definition)) {
             throw new \InvalidArgumentException(
@@ -80,7 +80,7 @@ class DefinitionHasMethodCallConstraint extends Constraint
         );
     }
 
-    private function equalArguments($expectedArguments, $actualArguments)
+    private function equalArguments(array $expectedArguments, array $actualArguments): bool
     {
         $constraint = new IsEqual(
             $expectedArguments

--- a/PhpUnit/DefinitionHasTagConstraint.php
+++ b/PhpUnit/DefinitionHasTagConstraint.php
@@ -11,13 +11,13 @@ class DefinitionHasTagConstraint extends Constraint
     private $name;
     private $attributes;
 
-    public function __construct($name, array $attributes = [])
+    public function __construct(string $name, array $attributes = [])
     {
         $this->name = $name;
         $this->attributes = $attributes;
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!($other instanceof Definition)) {
             throw new \InvalidArgumentException(
@@ -69,7 +69,7 @@ class DefinitionHasTagConstraint extends Constraint
         );
     }
 
-    private function equalAttributes($expectedAttributes, $actualAttributes)
+    private function equalAttributes(array $expectedAttributes, array $actualAttributes): bool
     {
         $constraint = new IsEqual(
             $expectedAttributes

--- a/PhpUnit/DefinitionIsChildOfConstraint.php
+++ b/PhpUnit/DefinitionIsChildOfConstraint.php
@@ -16,7 +16,7 @@ class DefinitionIsChildOfConstraint extends Constraint
         $this->expectedParentServiceId = $expectedParentServiceId;
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
     {
         if (!$other instanceof Definition) {
             throw new \InvalidArgumentException(
@@ -43,7 +43,7 @@ class DefinitionIsChildOfConstraint extends Constraint
         );
     }
 
-    private function evaluateDefinitionIsDecorator(Definition $definition, $returnResult)
+    private function evaluateDefinitionIsDecorator(Definition $definition, bool $returnResult): bool
     {
         if (!$definition instanceof ChildDefinition && !$definition instanceof DefinitionDecorator) {
             if ($returnResult) {
@@ -56,7 +56,7 @@ class DefinitionIsChildOfConstraint extends Constraint
         return true;
     }
 
-    private function evaluateDefinitionHasExpectedParentService($definition, $returnResult)
+    private function evaluateDefinitionHasExpectedParentService(Definition $definition, bool $returnResult): bool
     {
         $actualParentService = $this->expectedParentServiceId;
 

--- a/Tests/Fixtures/CollectServicesAndAddThemWithMethodCallsCompilerPass.php
+++ b/Tests/Fixtures/CollectServicesAndAddThemWithMethodCallsCompilerPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CollectServicesAndAddThemWithMethodCallsCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('collecting_service_id')) {
             return;

--- a/Tests/Fixtures/CollectServicesAndSetThemAsArgumentCompilerPass.php
+++ b/Tests/Fixtures/CollectServicesAndSetThemAsArgumentCompilerPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CollectServicesAndSetThemAsArgumentCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('collecting_service_id')) {
             return;

--- a/Tests/Fixtures/MatthiasDependencyInjectionTestExtension.php
+++ b/Tests/Fixtures/MatthiasDependencyInjectionTestExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class MatthiasDependencyInjectionTestExtension implements ExtensionInterface
 {
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
         // load some service definitions
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__));
@@ -38,11 +38,11 @@ class MatthiasDependencyInjectionTestExtension implements ExtensionInterface
         return 'matthias_dependency_injection_test';
     }
 
-    public function getNamespace()
+    public function getNamespace(): void
     {
     }
 
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): void
     {
     }
 }

--- a/Tests/Fixtures/NonPrependableTestExtension.php
+++ b/Tests/Fixtures/NonPrependableTestExtension.php
@@ -7,12 +7,12 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class NonPrependableTestExtension implements ExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $container->setParameter('ignored_invocation', 'ignored value');
     }
 
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
     }
 
@@ -21,11 +21,11 @@ class NonPrependableTestExtension implements ExtensionInterface
         return 'non_prependable_test';
     }
 
-    public function getNamespace()
+    public function getNamespace(): void
     {
     }
 
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): void
     {
     }
 }

--- a/Tests/Fixtures/PrependableTestExtension.php
+++ b/Tests/Fixtures/PrependableTestExtension.php
@@ -8,12 +8,12 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 class PrependableTestExtension implements ExtensionInterface, PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $container->setParameter('prepend_parameter_set', 'prepended value');
     }
 
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
     }
 
@@ -22,11 +22,11 @@ class PrependableTestExtension implements ExtensionInterface, PrependExtensionIn
         return 'prependable_test';
     }
 
-    public function getNamespace()
+    public function getNamespace(): void
     {
     }
 
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): void
     {
     }
 }

--- a/Tests/Fixtures/SimpleExtension.php
+++ b/Tests/Fixtures/SimpleExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class SimpleExtension implements ExtensionInterface
 {
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
     }
 
@@ -16,11 +16,11 @@ class SimpleExtension implements ExtensionInterface
         return 'simple';
     }
 
-    public function getNamespace()
+    public function getNamespace(): void
     {
     }
 
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): void
     {
     }
 }

--- a/Tests/Loader/LoaderFactoryTest.php
+++ b/Tests/Loader/LoaderFactoryTest.php
@@ -11,7 +11,7 @@ class LoaderFactoryTest extends TestCase
      * @test
      * @dataProvider fileProvider
      */
-    public function it_creates_the_appropriate_file_loader_based_on_the_extension($file, $expectedClass)
+    public function it_creates_the_appropriate_file_loader_based_on_the_extension($file, $expectedClass): void
     {
         $factory = new LoaderFactory();
         $loader = $factory->createLoaderForSource($this->createMockContainerBuilder(), $file);
@@ -22,9 +22,9 @@ class LoaderFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_a_closure_loader_when_source_is_a_closure()
+    public function it_creates_a_closure_loader_when_source_is_a_closure(): void
     {
-        $source = function () {
+        $source = function (): void {
         };
         $factory = new LoaderFactory();
 

--- a/Tests/PhpUnit/AbstractCompilerPassTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractCompilerPassTestCaseTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class AbstractCompilerPassTestCaseTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new CollectServicesAndAddThemWithMethodCallsCompilerPass());
         $container->addCompilerPass(new CollectServicesAndSetThemAsArgumentCompilerPass());
@@ -20,7 +20,7 @@ class AbstractCompilerPassTestCaseTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_adding_method_calls_these_can_be_asserted_to_exist()
+    public function if_compiler_pass_collects_services_by_adding_method_calls_these_can_be_asserted_to_exist(): void
     {
         $collectingService = new Definition();
         $this->setDefinition('collecting_service_id', $collectingService);
@@ -55,7 +55,7 @@ class AbstractCompilerPassTestCaseTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_setting_constructor_argument_it_can_be_asserted_to_exist()
+    public function if_compiler_pass_collects_services_by_setting_constructor_argument_it_can_be_asserted_to_exist(): void
     {
         $collectingService = new Definition();
         $this->setDefinition('collecting_service_id', $collectingService);

--- a/Tests/PhpUnit/AbstractExtensionConfigurationTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractExtensionConfigurationTestCaseTest.php
@@ -5,16 +5,18 @@ namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\SimpleConfiguration;
 use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\SimpleExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class AbstractExtensionConfigurationTestCaseTest extends AbstractExtensionConfigurationTestCase
 {
-    protected function getContainerExtension()
+    protected function getContainerExtension(): ExtensionInterface
     {
         return new SimpleExtension();
     }
 
-    protected function getConfiguration()
+    protected function getConfiguration(): ConfigurationInterface
     {
         return new SimpleConfiguration();
     }
@@ -22,11 +24,11 @@ class AbstractExtensionConfigurationTestCaseTest extends AbstractExtensionConfig
     /**
      * @test
      */
-    public function it_compares_expected_configuration_values_with_values_loaded_from_files()
+    public function it_compares_expected_configuration_values_with_values_loaded_from_files(): void
     {
         $sources = [
             __DIR__.'/../Fixtures/simple.php',
-            function (ContainerBuilder $container) {
+            function (ContainerBuilder $container): void {
                 $container->loadFromExtension(
                     'simple',
                     [

--- a/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new MatthiasDependencyInjectionTestExtension(),
@@ -18,7 +18,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_load_is_successful_it_does_not_fail()
+    public function if_load_is_successful_it_does_not_fail(): void
     {
         $this->load();
 
@@ -54,7 +54,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_service_is_undefined_it_fails()
+    public function if_service_is_undefined_it_fails(): void
     {
         $this->load();
 
@@ -66,7 +66,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_synthetic_service_is_undefined_it_fails()
+    public function if_synthetic_service_is_undefined_it_fails(): void
     {
         $this->load();
 
@@ -79,7 +79,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_service_is_defined_but_not_synthetic_it_fails()
+    public function if_service_is_defined_but_not_synthetic_it_fails(): void
     {
         $this->load();
 
@@ -92,7 +92,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_service_is_defined_but_has_another_class_it_fails()
+    public function if_service_is_defined_but_has_another_class_it_fails(): void
     {
         $this->load();
 
@@ -105,7 +105,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_alias_is_not_defined_it_fails()
+    public function if_alias_is_not_defined_it_fails(): void
     {
         $this->load();
 
@@ -117,7 +117,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_alias_exists_but_for_wrong_service_it_fails()
+    public function if_alias_exists_but_for_wrong_service_it_fails(): void
     {
         $this->load();
 
@@ -130,7 +130,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_parameter_does_not_exist_it_fails()
+    public function if_parameter_does_not_exist_it_fails(): void
     {
         $this->load();
 
@@ -143,7 +143,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_parameter_exists_but_has_wrong_value_it_fails()
+    public function if_parameter_exists_but_has_wrong_value_it_fails(): void
     {
         $this->load();
 
@@ -156,7 +156,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_does_not_have_argument_it_fails()
+    public function if_definition_does_not_have_argument_it_fails(): void
     {
         $this->load();
 
@@ -169,7 +169,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_has_argument_but_with_wrong_value_it_fails()
+    public function if_definition_has_argument_but_with_wrong_value_it_fails(): void
     {
         $this->load();
 
@@ -181,7 +181,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_is_decorated_and_argument_has_wrong_value_it_fails()
+    public function if_definition_is_decorated_and_argument_has_wrong_value_it_fails(): void
     {
         $this->load();
 
@@ -194,7 +194,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_is_decorated_but_by_the_wrong_parent_it_fails()
+    public function if_definition_is_decorated_but_by_the_wrong_parent_it_fails(): void
     {
         $this->load();
 
@@ -207,7 +207,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_should_be_decorated_when_it_is_not_it_fails()
+    public function if_definition_should_be_decorated_when_it_is_not_it_fails(): void
     {
         $this->load();
 
@@ -220,7 +220,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_should_have_a_method_call_and_it_has_not_it_fails()
+    public function if_definition_should_have_a_method_call_and_it_has_not_it_fails(): void
     {
         $this->load();
 
@@ -237,7 +237,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_definition_should_have_a_certain_arguments_for_a_method_call_and_it_has_not_it_fails()
+    public function if_definition_should_have_a_certain_arguments_for_a_method_call_and_it_has_not_it_fails(): void
     {
         $this->load();
 
@@ -254,7 +254,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_service_is_defined_it_fails()
+    public function if_service_is_defined_it_fails(): void
     {
         $this->load();
 
@@ -266,7 +266,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_service_is_not_defined_it_does_not_fail()
+    public function if_service_is_not_defined_it_does_not_fail(): void
     {
         $this->load();
 

--- a/Tests/PhpUnit/AbstractPrependExtensionTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractPrependExtensionTestCaseTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 class AbstractPrependExtensionTestCaseTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new PrependableTestExtension(),
@@ -20,7 +20,7 @@ class AbstractPrependExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function prepend_invoked_only_if_prepend_interface_is_implemented()
+    public function prepend_invoked_only_if_prepend_interface_is_implemented(): void
     {
         $this->load();
 
@@ -30,7 +30,7 @@ class AbstractPrependExtensionTestCaseTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function if_prepend_interface_is_not_implemented_prepend_is_not_invoked()
+    public function if_prepend_interface_is_not_implemented_prepend_is_not_invoked(): void
     {
         $this->load();
 

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -60,28 +60,6 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_expects_a_string_for_alias_id()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('string');
-
-        new ContainerBuilderHasAliasConstraint(new \stdClass(), 'service_id');
-    }
-
-    /**
-     * @test
-     */
-    public function it_expects_a_string_for_service_id()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('string');
-
-        new ContainerBuilderHasAliasConstraint('alias_id', new \stdClass());
-    }
-
-    /**
-     * @test
-     */
     public function it_does_not_change_case_of_aliased_service_ids()
     {
         $containerBuilder = new ContainerBuilder();

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -12,11 +12,11 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
      * @test
      * @dataProvider containerBuilderProvider
      */
-    public function match(ContainerBuilder $containerBuilder, $alias, $expectedServiceId, $shouldMatch)
+    public function match(ContainerBuilder $containerBuilder, $alias, $expectedServiceId, $shouldMatch): void
     {
         $constraint = new ContainerBuilderHasAliasConstraint($alias, $expectedServiceId);
 
-        $this->assertSame($shouldMatch, $constraint->evaluate($containerBuilder, null, true));
+        $this->assertSame($shouldMatch, $constraint->evaluate($containerBuilder, '', true));
     }
 
     public function containerBuilderProvider()
@@ -46,7 +46,7 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_has_a_string_representation()
+    public function it_has_a_string_representation(): void
     {
         $aliasId = 'alias_id';
         $serviceId = 'service_id';
@@ -60,12 +60,12 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_change_case_of_aliased_service_ids()
+    public function it_does_not_change_case_of_aliased_service_ids(): void
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setAlias('Interface', 'InterfaceImplementationService');
         $constraint = new ContainerBuilderHasAliasConstraint('Interface', 'InterfaceImplementationService');
 
-        $this->assertTrue($constraint->evaluate($containerBuilder, null, true));
+        $this->assertTrue($constraint->evaluate($containerBuilder, '', true));
     }
 }

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -4,7 +4,6 @@ namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasAliasConstraint;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ContainerBuilderHasAliasConstraintTest extends TestCase
@@ -85,10 +84,6 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
      */
     public function it_does_not_change_case_of_aliased_service_ids()
     {
-        if (!class_exists(ChildDefinition::class)) {
-            $this->markTestSkipped('This test requires at least Symfony 3.3');
-        }
-
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setAlias('Interface', 'InterfaceImplementationService');
         $constraint = new ContainerBuilderHasAliasConstraint('Interface', 'InterfaceImplementationService');

--- a/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
@@ -19,7 +19,7 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends TestCase
       $expectedClass,
       $checkExpectedClass,
       $shouldMatch
-    ) {
+    ): void {
         $constraint = new ContainerBuilderHasServiceDefinitionConstraint($serviceId, $expectedClass, $checkExpectedClass);
 
         $this->assertSame($shouldMatch, $constraint->evaluate($containerBuilder, '', true));
@@ -70,7 +70,7 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_has_a_string_representation()
+    public function it_has_a_string_representation(): void
     {
         $serviceId = 'some_service_id';
         $class = 'SomeClass';

--- a/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
@@ -80,26 +80,4 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends TestCase
             $constraint->toString()
         );
     }
-
-    /**
-     * @test
-     */
-    public function it_expects_a_string_for_service_id()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('string');
-
-        new ContainerBuilderHasServiceDefinitionConstraint(new \stdClass(), 'class');
-    }
-
-    /**
-     * @test
-     */
-    public function it_expects_a_string_for_class()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('string');
-
-        new ContainerBuilderHasServiceDefinitionConstraint('service_id', new \stdClass());
-    }
 }

--- a/Tests/PhpUnit/ContainerBuilderHasSyntheticServiceConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasSyntheticServiceConstraintTest.php
@@ -23,7 +23,7 @@ class ContainerBuilderHasSyntheticServiceConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_fails_if_the_service_definition_is_a_regular_definition()
+    public function it_fails_if_the_service_definition_is_a_regular_definition(): void
     {
         $this->containerBuilder->setDefinition('synthetic_service', new Definition());
 
@@ -35,7 +35,7 @@ class ContainerBuilderHasSyntheticServiceConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_fail_if_the_synthetic_service_definition_exists()
+    public function it_does_not_fail_if_the_synthetic_service_definition_exists(): void
     {
         $this->containerBuilder->setDefinition('synthetic_service', $this->createSyntheticDefinition());
 
@@ -47,7 +47,7 @@ class ContainerBuilderHasSyntheticServiceConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_fail_if_the_synthetic_service_has_been_provided_already()
+    public function it_does_not_fail_if_the_synthetic_service_has_been_provided_already(): void
     {
         $this->containerBuilder->setDefinition('synthetic_service', $this->createSyntheticDefinition());
         $this->containerBuilder->set('synthetic_service', new \stdClass());
@@ -65,12 +65,12 @@ class ContainerBuilderHasSyntheticServiceConstraintTest extends TestCase
         return $syntheticDefinition;
     }
 
-    private function assertConstraintFails(Constraint $constraint)
+    private function assertConstraintFails(Constraint $constraint): void
     {
         $this->assertFalse($constraint->evaluate($this->containerBuilder, '', true));
     }
 
-    private function assertConstraintPasses(Constraint $constraint)
+    private function assertConstraintPasses(Constraint $constraint): void
     {
         $this->assertTrue($constraint->evaluate($this->containerBuilder, '', true));
     }

--- a/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
+++ b/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
@@ -18,7 +18,7 @@ class ContainerHasParameterConstraintTest extends TestCase
       $parameterValue,
       $checkParameterValue,
       $expectedToMatch
-    ) {
+    ): void {
         $constraint = new ContainerHasParameterConstraint($parameterName, $parameterValue, $checkParameterValue);
 
         $this->assertSame($expectedToMatch, $constraint->evaluate($container, '', true));

--- a/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
@@ -32,7 +32,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
     /**
      * @test
      */
-    public function it_fails_if_the_service_definition_is_not_a_service_locator()
+    public function it_fails_if_the_service_definition_is_not_a_service_locator(): void
     {
         $this->containerBuilder->setDefinition('not_a_service_locator', new Definition());
         $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [new Reference('not_a_service_locator')]));
@@ -43,7 +43,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
     /**
      * @test
      */
-    public function if_fails_if_the_service_definition_value_references_a_missing_service()
+    public function if_fails_if_the_service_definition_value_references_a_missing_service(): void
     {
         $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [new Reference('not_a_service_locator')]));
 
@@ -57,7 +57,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
      *
      * @dataProvider provideInvalidServiceLocatorReferences
      */
-    public function if_fails_if_the_service_definition_value_is_not_a_valid_reference($arguments)
+    public function if_fails_if_the_service_definition_value_is_not_a_valid_reference($arguments): void
     {
         $this->containerBuilder->setDefinition('service_locator', new Definition(ServiceLocator::class, $arguments));
         $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [new Reference('service_locator')]));
@@ -76,7 +76,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
     /**
      * @test
      */
-    public function it_does_not_fail_if_the_service_definition_is_a_service_locator()
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator(): void
     {
         $definition = new Definition(ServiceLocator::class, [['bar' => new ServiceClosureArgument(new Reference('foo'))]]);
         $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [null, '$l' => $definition]));
@@ -87,7 +87,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
     /**
      * @test
      */
-    public function it_does_not_fail_if_the_service_definition_is_a_service_locator_reference()
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator_reference(): void
     {
         $id = ServiceLocatorTagPass::register($this->containerBuilder, ['bar' => new Reference('foo')]);
         $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [$id]));
@@ -100,7 +100,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
     /**
      * @test
      */
-    public function it_does_not_fail_if_the_service_definition_is_a_service_locator_with_a_with_a_context()
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator_with_a_with_a_context(): void
     {
         $id = ServiceLocatorTagPass::register($this->containerBuilder, ['bar' => new Reference('foo')], 'using_service');
         $this->containerBuilder->setDefinition('using_service', new Definition(\stdClass::class, [$id]));
@@ -110,12 +110,12 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
         );
     }
 
-    private function assertConstraintFails(Constraint $constraint)
+    private function assertConstraintFails(Constraint $constraint): void
     {
         $this->assertFalse($constraint->evaluate($this->containerBuilder, '', true));
     }
 
-    private function assertConstraintPasses(Constraint $constraint)
+    private function assertConstraintPasses(Constraint $constraint): void
     {
         $this->assertTrue($constraint->evaluate($this->containerBuilder, '', false));
     }

--- a/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
+++ b/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
@@ -30,7 +30,7 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
     /**
      * @test
      */
-    public function it_fails_if_the_service_definition_is_not_a_service_locator()
+    public function it_fails_if_the_service_definition_is_not_a_service_locator(): void
     {
         $this->assertConstraintFails(new DefinitionEqualsServiceLocatorConstraint([]), new Definition());
         $this->assertConstraintFails(new DefinitionEqualsServiceLocatorConstraint([]), new Definition(\stdClass::class));
@@ -41,7 +41,7 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
      *
      * @dataProvider provideInvalidServiceLocatorReferences
      */
-    public function if_fails_if_the_service_definition_value_is_not_a_valid_reference($arguments)
+    public function if_fails_if_the_service_definition_value_is_not_a_valid_reference($arguments): void
     {
         $this->assertConstraintFails(
             new DefinitionEqualsServiceLocatorConstraint([]),
@@ -62,7 +62,7 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
      *
      * @dataProvider provideValidServiceLocatorDefs
      */
-    public function it_does_not_fail_if_the_service_definition_is_a_service_locator(array $defArguments, array $expected)
+    public function it_does_not_fail_if_the_service_definition_is_a_service_locator(array $defArguments, array $expected): void
     {
         $this->assertConstraintPasses(
             new DefinitionEqualsServiceLocatorConstraint($expected),
@@ -101,12 +101,12 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
         ];
     }
 
-    private function assertConstraintFails(Constraint $constraint, $value)
+    private function assertConstraintFails(Constraint $constraint, $value): void
     {
         $this->assertFalse($constraint->evaluate($value, '', true));
     }
 
-    private function assertConstraintPasses(Constraint $constraint, $value)
+    private function assertConstraintPasses(Constraint $constraint, $value): void
     {
         $this->assertTrue($constraint->evaluate($value, '', true));
     }

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -15,7 +15,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
      * @test
      * @dataProvider definitionProvider
      */
-    public function match(Definition $definition, $argumentIndex, $expectedValue, $shouldMatch)
+    public function match(Definition $definition, $argumentIndex, $expectedValue, $shouldMatch): void
     {
         $constraint = new DefinitionHasArgumentConstraint($argumentIndex, $expectedValue);
 
@@ -61,7 +61,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
      * @param mixed  $argument
      * @param string $exceptionMessage
      */
-    public function validates_definitionIndex($argument, $exceptionMessage)
+    public function validates_definitionIndex($argument, $exceptionMessage): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($exceptionMessage);
@@ -101,7 +101,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
      *
      * @param int $argumentIndex
      */
-    public function supports_indexed_arguments($argumentIndex)
+    public function supports_indexed_arguments($argumentIndex): void
     {
         $expectedValue = 'bar';
 
@@ -145,7 +145,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
      *
      * @param string $argument
      */
-    public function supports_named_arguments($argument)
+    public function supports_named_arguments($argument): void
     {
         $expectedValue = 'bar';
 

--- a/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
@@ -12,7 +12,7 @@ class DefinitionHasMethodCallConstraintTest extends TestCase
      * @test
      * @dataProvider definitionProvider
      */
-    public function match(Definition $definition, $method, $arguments, $index, $expectedToMatch)
+    public function match(Definition $definition, $method, $arguments, $index, $expectedToMatch): void
     {
         $constraint = new DefinitionHasMethodCallConstraint($method, $arguments, $index);
 
@@ -50,7 +50,7 @@ class DefinitionHasMethodCallConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_has_a_string_representation()
+    public function it_has_a_string_representation(): void
     {
         $method = 'methodName';
         $constraint = new DefinitionHasMethodCallConstraint($method, []);

--- a/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
@@ -13,7 +13,7 @@ class DefinitionHasTagConstraintTest extends TestCase
      * @test
      * @dataProvider definitionProvider
      */
-    public function match(Definition $definition, $tag, $attributes, $expectedToMatch)
+    public function match(Definition $definition, $tag, $attributes, $expectedToMatch): void
     {
         $constraint = new DefinitionHasTagConstraint($tag, $attributes);
 
@@ -24,7 +24,7 @@ class DefinitionHasTagConstraintTest extends TestCase
      * @test
      * @dataProvider definitionProvider
      */
-    public function evaluateThrowsExceptionOnFailure(Definition $definition, $tag, $attributes, $expectedToMatch)
+    public function evaluateThrowsExceptionOnFailure(Definition $definition, $tag, $attributes, $expectedToMatch): void
     {
         $constraint = new DefinitionHasTagConstraint($tag, $attributes);
 
@@ -70,7 +70,7 @@ class DefinitionHasTagConstraintTest extends TestCase
     /**
      * @test
      */
-    public function it_has_a_string_representation()
+    public function it_has_a_string_representation(): void
     {
         $tag = 'tagName';
         $constraint = new DefinitionHasTagConstraint($tag, []);

--- a/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
@@ -14,7 +14,7 @@ class DefinitionIsChildOfConstraintTest extends TestCase
      * @test
      * @dataProvider definitionProvider
      */
-    public function match(Definition $definition, $parentServiceId, $expectedToMatch)
+    public function match(Definition $definition, $parentServiceId, $expectedToMatch): void
     {
         $constraint = new DefinitionIsChildOfConstraint($parentServiceId);
 

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "require": {
         "php": "^7.2",
         "matthiasnoback/symfony-config-test": "^4.0.1",
-        "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
-        "symfony/config": "^2.7 || ^3.3 || ^4.0",
-        "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
+        "symfony/dependency-injection": "^3.4 || ^4.0",
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/yaml": "^3.4 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
This PR removes support for old versions of Symfony, but there might still be code that can be removed. Also, type hints were added where obvious. To be merged before #113 