### PR TITLE
Add DefinitionConstraint to ensure service argument is a valid Reference to another service definition

### DIFF
--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -171,6 +171,24 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
     }
 
     /**
+     * Assert that the ContainerBuilder for this test has a service definition with the given id, which has an argument
+     * at the given index, and its value is a ServiceLocator with a reference-map equal to the given value.
+     *
+     * @param int|string $argumentIndex
+     * @param array      $expectedServiceMap an array of service-id references and their key in the map
+     */
+    final protected function assertContainerBuilderHasServiceDefinitionWithServiceDefinitionArgument(
+        string $serviceId,
+        $argumentIndex,
+        $expectedValue
+    ): void {
+        self::assertThat(
+            $this->container,
+            new DefinitionArgumentEqualsServiceDefinitionConstraint($serviceId, $argumentIndex, $expectedValue)
+        );
+    }
+
+    /**
      * Assert that the ContainerBuilder for this test has a service definition with the given id, which has a method
      * call to the given method with the given arguments.
      *

--- a/PhpUnit/DefinitionArgumentEqualsServiceDefinitionConstraint.php
+++ b/PhpUnit/DefinitionArgumentEqualsServiceDefinitionConstraint.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class DefinitionArgumentEqualsServiceDefinitionConstraint extends Constraint
+{
+    /**
+     * @var int|string
+     */
+    private $argumentIndex;
+    private $expectedValue;
+    private $serviceId;
+
+    public function __construct(string $serviceId, $argumentIndex, $expectedValue)
+    {
+        if (!(is_string($argumentIndex) || (is_int($argumentIndex) && $argumentIndex >= 0))) {
+            throw new \InvalidArgumentException('Expected either a string or a positive integer for $argumentIndex.');
+        }
+
+        if (is_string($argumentIndex)) {
+            if ('' === $argumentIndex) {
+                throw new \InvalidArgumentException('A named argument must begin with a "$".');
+            }
+
+            if ('$' !== $argumentIndex[0]) {
+                throw new \InvalidArgumentException(
+                    sprintf('Unknown argument "%s". Did you mean "$%s"?', $argumentIndex, $argumentIndex)
+                );
+            }
+        }
+
+        $this->serviceId = $serviceId;
+        $this->argumentIndex = $argumentIndex;
+        $this->expectedValue = is_string($expectedValue) ? new Reference($expectedValue) : $expectedValue;
+    }
+
+    public function toString(): string
+    {
+        if (is_string($this->argumentIndex)) {
+            return sprintf(
+                'has an argument named "%s" with the ServiceLocator',
+                $this->argumentIndex
+            );
+        }
+
+        return sprintf(
+            'has an argument with index %d with the ServiceLocator',
+            $this->argumentIndex
+        );
+    }
+
+    public function evaluate($other, string $description = '', bool $returnResult = false): bool
+    {
+        if (!($other instanceof ContainerBuilder)) {
+            throw new \InvalidArgumentException(
+                'Expected an instance of Symfony\Component\DependencyInjection\ContainerBuilder'
+            );
+        }
+
+        if (!$this->evaluateArgumentIndex($other->findDefinition($this->serviceId), $returnResult)) {
+            return false;
+        }
+
+        if (!$this->evaluateArgumentValue($other, $returnResult)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function evaluateArgumentIndex(Definition $definition, bool $returnResult): bool
+    {
+        try {
+            $definition->getArgument($this->argumentIndex);
+        } catch (OutOfBoundsException $exception) {
+            if ($returnResult) {
+                return false;
+            }
+
+            $this->fail(
+                $definition,
+                sprintf('The definition has no argument with index %s', $this->argumentIndex)
+            );
+        }
+
+        return true;
+    }
+
+    private function evaluateArgumentValue(ContainerBuilder $container, bool $returnResult): bool
+    {
+        $definition = $container->findDefinition($this->serviceId);
+        $actualValue = $definition->getArgument($this->argumentIndex);
+
+        if (!$actualValue instanceof Reference) {
+            $this->fail(
+                $definition,
+                sprintf(
+                    'The definition argument %s must be a Reference of %s',
+                    $this->argumentIndex,
+                    $this->expectedValue
+                )
+            );
+        }
+
+        return $returnResult & $this->expectedValue !== $actualValue;
+    }
+}

--- a/Tests/Fixtures/AutowiringDependencyInjectionTestExtension.php
+++ b/Tests/Fixtures/AutowiringDependencyInjectionTestExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class AutowiringDependencyInjectionTestExtension implements ExtensionInterface
+{
+    public function load(array $config, ContainerBuilder $container): void
+    {
+        // load some service definitions
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
+        $loader->load('services.yaml');
+    }
+
+    public function getAlias()
+    {
+        return 'autowiring_dependency_injection_test';
+    }
+
+    public function getNamespace(): void
+    {
+    }
+
+    public function getXsdValidationBasePath(): void
+    {
+    }
+}

--- a/Tests/Fixtures/ClassWithInjectedServiceDefinitions.php
+++ b/Tests/Fixtures/ClassWithInjectedServiceDefinitions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures;
+
+class ClassWithInjectedServiceDefinitions
+{
+    private $loadedClass;
+
+    public function __construct(ClassLoadedByServiceDefinition $loadedClass)
+    {
+        $this->loadedClass = $loadedClass;
+    }
+
+    public function getLoadedClass(): ClassLoadedByServiceDefinition
+    {
+        return $this->loadedClass;
+    }
+}

--- a/Tests/Fixtures/services.yaml
+++ b/Tests/Fixtures/services.yaml
@@ -1,0 +1,20 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassWithInjectedServiceDefinitions: ~
+  Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassLoadedByServiceDefinition: ~
+
+  class_without_autowiring_invalid_argument_definition:
+    autowire: false
+    class: Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassWithInjectedServiceDefinitions
+    arguments:
+      $loadedClass: Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassLoadedByServiceDefinition
+
+  class_without_autowiring_valid_argument_definition:
+    autowire: false
+    class:    Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassWithInjectedServiceDefinitions
+    arguments:
+      $loadedClass: '@Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassLoadedByServiceDefinition'

--- a/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
@@ -3,6 +3,8 @@
 namespace Matthias\DependencyInjectionTests\Test\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\AutowiringDependencyInjectionTestExtension;
+use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\ClassLoadedByServiceDefinition;
 use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\MatthiasDependencyInjectionTestExtension;
 use PHPUnit\Framework\ExpectationFailedException;
 
@@ -12,6 +14,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     {
         return [
             new MatthiasDependencyInjectionTestExtension(),
+            new AutowiringDependencyInjectionTestExtension(),
         ];
     }
 
@@ -271,5 +274,63 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
         $this->load();
 
         $this->assertContainerBuilderNotHasService('undefined');
+    }
+
+    /**
+     * @test
+     */
+    public function if_service_argument_is_a_valid_argument(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'class_without_autowiring_valid_argument_definition',
+            '$loadedClass',
+            ClassLoadedByServiceDefinition::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function if_service_argument_is_a_valid_argument_even_not_being_a_reference(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'class_without_autowiring_invalid_argument_definition',
+            '$loadedClass',
+            ClassLoadedByServiceDefinition::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function if_service_argument_is_a_valid_definition(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithServiceDefinitionArgument(
+            'class_without_autowiring_valid_argument_definition',
+            '$loadedClass',
+            ClassLoadedByServiceDefinition::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function if_service_argument_is_a_invalid_definition(): void
+    {
+        $this->load();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithServiceDefinitionArgument(
+            'class_without_autowiring_invalid_argument_definition',
+            '$loadedClass',
+            ClassLoadedByServiceDefinition::class
+        );
     }
 }


### PR DESCRIPTION
In Yaml service definitions, if '@' is forgotten to be added as a prefix of the service id passed as an argument, the assertion "assertContainerBuilderHasServiceDefinitionWithArgument" pass even being an invalid type.

I have added a new assertion just to ensure that the argument is a valid reference to a valid object and a regression test with a valid and invalid cases that demonstrates this issue.
