### PR TITLE
AbstractContainerBuilderTestCase also resets After removing passes

### DIFF
--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -20,6 +20,7 @@ abstract class AbstractContainerBuilderTestCase extends TestCase
         $this->container = new ContainerBuilder();
         $this->container->getCompilerPassConfig()->setOptimizationPasses([]);
         $this->container->getCompilerPassConfig()->setRemovingPasses([]);
+        $this->container->getCompilerPassConfig()->setAfterRemovingPasses([]);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This is necessary because https://github.com/symfony/symfony/pull/32332 configures some After removing passes.

I discovered this issue when trying to fix tests for [mhujer/consistence-bundle](https://github.com/mhujer/consistence-bundle) which were failing [for a strange reason](https://travis-ci.org/mhujer/consistence-bundle/jobs/608102312#L319) - `@translator` service not available after upgrading to SF 4.4 