### PR TITLE
Fix executing prepend first with multiple extensions

### DIFF
--- a/PhpUnit/AbstractExtensionTestCase.php
+++ b/PhpUnit/AbstractExtensionTestCase.php
@@ -53,7 +53,9 @@ abstract class AbstractExtensionTestCase extends AbstractContainerBuilderTestCas
             if ($extension instanceof PrependExtensionInterface) {
                 $extension->prepend($this->container);
             }
+        }
 
+        foreach ($this->container->getExtensions() as $extension) {
             $extension->load($configs, $this->container);
         }
     }

--- a/Tests/Fixtures/DependableExtension.php
+++ b/Tests/Fixtures/DependableExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+class DependableExtension implements ExtensionInterface
+{
+    public function load(array $config, ContainerBuilder $container): void
+    {
+        if ($container->hasParameter('parameter_from_non_dependable')) {
+            $container->setParameter('dependable_parameter', 'dependable value');
+        }
+    }
+
+    public function getAlias()
+    {
+        return 'dependable';
+    }
+
+    public function getNamespace(): void
+    {
+    }
+
+    public function getXsdValidationBasePath(): void
+    {
+    }
+}

--- a/Tests/Fixtures/NonDependablePrependableExtension.php
+++ b/Tests/Fixtures/NonDependablePrependableExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+class NonDependablePrependableExtension implements ExtensionInterface, PrependExtensionInterface
+{
+    public function load(array $config, ContainerBuilder $container): void
+    {
+    }
+
+    public function getAlias()
+    {
+        return 'non_dependable';
+    }
+
+    public function getNamespace(): void
+    {
+    }
+
+    public function getXsdValidationBasePath(): void
+    {
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $container->setParameter('parameter_from_non_dependable', 'non-dependable value');
+    }
+}

--- a/Tests/PhpUnit/AbstractDependableExtensionTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractDependableExtensionTestCaseTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Matthias\DependencyInjectionTests\Test\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\DependableExtension;
+use Matthias\SymfonyDependencyInjectionTest\Tests\Fixtures\NonDependablePrependableExtension;
+
+class AbstractDependableExtensionTestCaseTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new DependableExtension(),
+            new NonDependablePrependableExtension(),
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function prepend_invoked_before_any_load(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('dependable_parameter', 'dependable value');
+    }
+}


### PR DESCRIPTION
If there are multiple extensions defined in a class that extends from `AbstractExtensionTestCase`, when you call `load`, [it iterates the extensions and for each one calls `prepend` and then `load`](https://github.com/SymfonyTest/SymfonyDependencyInjectionTest/blob/master/PhpUnit/AbstractExtensionTestCase.php#L52-L58). This is wrong because it should execute the `prepend` method of each one before any `load`.