### PR TITLE
Add @coversNothing annotation to prevent raising risky warnings in PHPUnit 9.2

### DIFF
--- a/PhpUnit/AbstractCompilerPassTestCase.php
+++ b/PhpUnit/AbstractCompilerPassTestCase.php
@@ -18,6 +18,7 @@ abstract class AbstractCompilerPassTestCase extends AbstractContainerBuilderTest
      * This test will run the compile method.
      *
      * @test
+     * @coversNothing
      */
     final public function compilation_should_not_fail_with_empty_container(): void
     {


### PR DESCRIPTION
PHPUnit added a warning when a test method is missing `@covers*` annotation and one is using `forceCoversAnnotation` config: https://github.com/sebastianbergmann/phpunit/issues/4246 .

Running the tests on PHPUnit 9.2 without this results in:

```
33) App\MyCompilerPass::compilation_should_not_fail_with_empty_container
This test does not have a @covers annotation but is expected to have one
```

Since this test method is final, we cannot override it in our project, so this is the best way to fix this.