### PR TITLE
Make it easy to copy require command from Github interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ these classes.
 
 Using Composer:
 
-    php composer.phar require --dev matthiasnoback/symfony-dependency-injection-test
+```bash
+composer require --dev matthiasnoback/symfony-dependency-injection-test
+```
 
 ## Usage
 


### PR DESCRIPTION
This PR will allow users to easy copy the `require` command by clicking the 'Copy to clipboard' button provided by the GitHub interface