### PR TITLE
fix: don't apply config to all registered extensions

### DIFF
--- a/PhpUnit/AbstractExtensionTestCase.php
+++ b/PhpUnit/AbstractExtensionTestCase.php
@@ -55,7 +55,7 @@ abstract class AbstractExtensionTestCase extends AbstractContainerBuilderTestCas
             }
         }
 
-        foreach ($this->container->getExtensions() as $extension) {
+        foreach ($this->getContainerExtensions() as $extension) {
             $extension->load($configs, $this->container);
         }
     }


### PR DESCRIPTION
Allows the user to register additional extensions which then will not be configured with local configuration, which doesn't work anyway.

See #78