### PR TITLE
Fix PHP Fatal error when installed with --prefer-lowest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "matthiasnoback/symfony-config-test": "^4.0.1",
+        "matthiasnoback/symfony-config-test": "^4.2.0",
         "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
         "symfony/config": "^4.4 || ^5.3 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.3 || ^6.0"


### PR DESCRIPTION
Hi!
I publish this PR to fix a PHP Fatal error I faced when I installed the bundle with php7.4 with `--prefer-lowest` flag
The error is the following:

```
PHP Fatal error:  Declaration of Matthias\SymfonyConfigTest\PhpUnit\ProcessedConfigurationEqualsConstraint::evaluate($other, $description = '', $returnResult = false) must be compatible with PHPUnit\Framework\Constraint\Constraint::evaluate($other, string $description = '', bool $returnResult = false): ?bool .../vendor/matthiasnoback/symfony-config-test/PhpUnit/ProcessedConfigurationEqualsConstraint.php on line 23
```

as you can see, the strong typed return `: ?bool` is not present in https://github.com/SymfonyTest/SymfonyConfigTest/blob/4.0.1/PhpUnit/ProcessedConfigurationEqualsConstraint.php#L23
 as in  https://github.com/sebastianbergmann/phpunit/blob/9.5.0/src/Framework/Constraint/Constraint.php#L42

Thanks for maintaining this repo!