### PR TITLE
Add PhpUnit 9.x to the supported version matrix in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,9 @@ container:
 
 ## Version Guidance
 
-| Version | Released     | PHPUnit    | Status     |
-|---------|--------------|------------|------------|
-| 4.x     | Mar 28, 2019 | 8.x        | Latest     |
-| 3.x     | Mar 5, 2018  | 7.x        | Bugfixes   |
-| 2.x     | May 9, 2017  | 6.x        | Bugfixes   |
-| 1.x     | Jul 4, 2016  | 4.x and 5x | EOL        |
+| Version | Released     | PHPUnit     | Status     |
+|---------|--------------|-------------|------------|
+| 4.x     | Mar 28, 2019 | 8.x and 9.x | Latest     |
+| 3.x     | Mar 5, 2018  | 7.x         | Bugfixes   |
+| 2.x     | May 9, 2017  | 6.x         | Bugfixes   |
+| 1.x     | Jul 4, 2016  | 4.x and 5.x | EOL        |


### PR DESCRIPTION
According to the `composer.json` PhpUnit 9.x is supported, so I added it to the version matrix in the readme.