### PR TITLE
5.0 Proposal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,21 +11,18 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.2'
-          - '7.3'
-          - '7.4'
-          - '8.0'
+          - '8.1'
+          - '8.2'
         dependency:
           - ''
         symfony:
-          - '4.4.*'
-          - '5.3.*'
+          - '5.4.*'
+          - '6.2.*'
+          - '6.3.*'
         include:
-          - php: '7.2'
-            symfony: '4.4.*'
+          - php: '8.1'
+            symfony: '5.4.*'
             dependency: 'lowest'
-          - php: '8.0'
-            symfony: '6.0.*'
       fail-fast: false
     steps:
       - name: Checkout
@@ -38,18 +35,12 @@ jobs:
           extensions: pcov
           tools: flex
 
-      - name: Prefer unstable Composer dependencies for Symfony 6.0
-        if: matrix.symfony == '6.0.*'
-        run: |
-          composer config prefer-stable false
-          composer config minimum-stability dev
-
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/Loader/LoaderFactory.php
+++ b/Loader/LoaderFactory.php
@@ -7,7 +7,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
-use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;

--- a/Loader/LoaderFactory.php
+++ b/Loader/LoaderFactory.php
@@ -56,9 +56,4 @@ final class LoaderFactory implements LoaderFactoryInterface
     {
         return new PhpFileLoader($container, new FileLocator());
     }
-
-    public function createIniFileLoader(ContainerBuilder $container): IniFileLoader
-    {
-        return new IniFileLoader($container, new FileLocator());
-    }
 }

--- a/Tests/Fixtures/SimpleConfiguration.php
+++ b/Tests/Fixtures/SimpleConfiguration.php
@@ -10,12 +10,7 @@ class SimpleConfiguration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('simple');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            $rootNode = $treeBuilder->root('simple');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->fixXmlConfig('type', 'types')

--- a/Tests/Loader/LoaderFactoryTest.php
+++ b/Tests/Loader/LoaderFactoryTest.php
@@ -15,6 +15,7 @@ class LoaderFactoryTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider fileProvider
      */
     public function it_creates_the_appropriate_file_loader_based_on_the_extension($file, $expectedClass): void

--- a/Tests/Loader/LoaderFactoryTest.php
+++ b/Tests/Loader/LoaderFactoryTest.php
@@ -3,7 +3,13 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\Loader;
 
 use Matthias\SymfonyDependencyInjectionTest\Loader\LoaderFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class LoaderFactoryTest extends TestCase
 {
@@ -29,25 +35,21 @@ class LoaderFactoryTest extends TestCase
         $factory = new LoaderFactory();
 
         $loader = $factory->createLoaderForSource($this->createMockContainerBuilder(), $source);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Loader\ClosureLoader', $loader);
+        $this->assertInstanceOf(ClosureLoader::class, $loader);
     }
 
-    public function fileProvider()
+    public static function fileProvider()
     {
         return [
-            ['file.xml', 'Symfony\Component\DependencyInjection\Loader\XmlFileLoader'],
-            ['file.yml', 'Symfony\Component\DependencyInjection\Loader\YamlFileLoader'],
-            ['file.yaml', 'Symfony\Component\DependencyInjection\Loader\YamlFileLoader'],
-            ['file.php', 'Symfony\Component\DependencyInjection\Loader\PhpFileLoader'],
+            ['file.xml', XmlFileLoader::class],
+            ['file.yml', YamlFileLoader::class],
+            ['file.yaml', YamlFileLoader::class],
+            ['file.php', PhpFileLoader::class],
         ];
     }
 
-    private function createMockContainerBuilder()
+    private function createMockContainerBuilder(): MockObject&ContainerBuilder
     {
-        return $this
-            ->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->disableOriginalConstructor()
-            ->setMethods(null)
-            ->getMock();
+        return $this->createMock(ContainerBuilder::class);
     }
 }

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -10,6 +10,7 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider containerBuilderProvider
      */
     public function match(ContainerBuilder $containerBuilder, $alias, $expectedServiceId, $shouldMatch): void

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -19,7 +19,7 @@ class ContainerBuilderHasAliasConstraintTest extends TestCase
         $this->assertSame($shouldMatch, $constraint->evaluate($containerBuilder, '', true));
     }
 
-    public function containerBuilderProvider()
+    public static function containerBuilderProvider()
     {
         $emptyContainerBuilder = new ContainerBuilder();
 

--- a/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
@@ -25,7 +25,7 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends TestCase
         $this->assertSame($shouldMatch, $constraint->evaluate($containerBuilder, '', true));
     }
 
-    public function containerBuilderProvider()
+    public static function containerBuilderProvider()
     {
         $emptyContainerBuilder = new ContainerBuilder();
 

--- a/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
@@ -11,6 +11,7 @@ class ContainerBuilderHasServiceDefinitionConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider containerBuilderProvider
      */
     public function match(

--- a/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
@@ -22,10 +22,6 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
 
     protected function setUp(): void
     {
-        if (!class_exists(ServiceLocator::class)) {
-            $this->markTestSkipped('Requires the Symfony DependencyInjection component v3.4 or higher');
-        }
-
         $this->containerBuilder = new ContainerBuilder();
     }
 

--- a/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraintTest.php
@@ -65,7 +65,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraintTest extends TestCas
         $this->assertConstraintFails(new DefinitionArgumentEqualsServiceLocatorConstraint('using_service', 0, [new Reference('foo')]));
     }
 
-    public function provideInvalidServiceLocatorReferences()
+    public static function provideInvalidServiceLocatorReferences()
     {
         yield [['']];
         yield [[null]];

--- a/Tests/PhpUnit/DefinitionDecoratesConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionDecoratesConstraintTest.php
@@ -12,6 +12,7 @@ class DefinitionDecoratesConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider containerBuilderProvider
      */
     public function match(ContainerBuilder $containerBuilder, bool $expectedToMatch, string $serviceId, string $decoratedServiceId, ?string $renamedId, int $priority, ?int $invalidBehavior): void
@@ -46,6 +47,7 @@ class DefinitionDecoratesConstraintTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider stringRepresentationProvider
      */
     public function it_has_a_string_representation(DefinitionDecoratesConstraint $constraint, string $expectedRepresentation): void

--- a/Tests/PhpUnit/DefinitionDecoratesConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionDecoratesConstraintTest.php
@@ -21,7 +21,7 @@ class DefinitionDecoratesConstraintTest extends TestCase
         $this->assertSame($expectedToMatch, $constraint->evaluate($containerBuilder, '', true));
     }
 
-    public function containerBuilderProvider(): iterable
+    public static function containerBuilderProvider(): iterable
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setDefinition('decorated1', new Definition('DecoratedClass1'));
@@ -53,7 +53,7 @@ class DefinitionDecoratesConstraintTest extends TestCase
         $this->assertSame($expectedRepresentation, $constraint->toString());
     }
 
-    public function stringRepresentationProvider(): iterable
+    public static function stringRepresentationProvider(): iterable
     {
         yield [new DefinitionDecoratesConstraint('decorator', 'decorated'), '"decorator" decorates service "decorated" with priority "0" and "RUNTIME_EXCEPTION_ON_INVALID_REFERENCE" behavior.'];
         yield [new DefinitionDecoratesConstraint('decorator', 'decorated', 'decorated_0'), '"decorator" decorates service "decorated" and renames it to "decorated_0" with priority "0" and "RUNTIME_EXCEPTION_ON_INVALID_REFERENCE" behavior.'];

--- a/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
+++ b/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
@@ -49,7 +49,7 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
         );
     }
 
-    public function provideInvalidServiceLocatorReferences()
+    public static function provideInvalidServiceLocatorReferences()
     {
         yield [['']];
         yield [[null]];
@@ -70,7 +70,7 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
         );
     }
 
-    public function provideValidServiceLocatorDefs()
+    public static function provideValidServiceLocatorDefs()
     {
         // Data providers get called before setUp?
         if (!class_exists(ServiceLocator::class)) {

--- a/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
+++ b/Tests/PhpUnit/DefinitionEqualsServiceLocatorTest.php
@@ -20,10 +20,6 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!class_exists(ServiceLocator::class)) {
-            $this->markTestSkipped('Requires the Symfony DependencyInjection component v3.4 or higher');
-        }
-
         $this->containerBuilder = new ContainerBuilder();
     }
 
@@ -72,11 +68,6 @@ final class DefinitionEqualsServiceLocatorTest extends TestCase
 
     public static function provideValidServiceLocatorDefs()
     {
-        // Data providers get called before setUp?
-        if (!class_exists(ServiceLocator::class)) {
-            return [[], []];
-        }
-
         yield [
             ['bar' => new ServiceClosureArgument(new Reference('foo'))],
             ['bar' => new Reference('foo')],

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -33,11 +33,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
         $definitionWithArguments->setArguments($arguments);
 
         $parentServiceId = 'parent_service_id';
-        if (class_exists(ChildDefinition::class)) {
-            $decoratedDefinitionWithArguments = new ChildDefinition($parentServiceId);
-        } else {
-            $decoratedDefinitionWithArguments = new DefinitionDecorator($parentServiceId);
-        }
+        $decoratedDefinitionWithArguments = new ChildDefinition($parentServiceId);
 
         $decoratedDefinitionWithArguments->setArguments([0 => 'first argument', 1 => $wrongValue]);
         $decoratedDefinitionWithArguments->replaceArgument(1, $rightValue);

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 class DefinitionHasArgumentConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider definitionProvider
      */
     public function match(Definition $definition, $argumentIndex, $expectedValue, $shouldMatch): void
@@ -52,6 +52,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider invalid_definition_indexes
      *
      * @param mixed  $argument
@@ -93,6 +94,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider indexed_arguments
      *
      * @param int $argumentIndex
@@ -139,6 +141,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider named_arguments
      *
      * @param string $argument

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -22,7 +22,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
         $this->assertSame($shouldMatch, $constraint->evaluate($definition, '', true));
     }
 
-    public function definitionProvider()
+    public static function definitionProvider()
     {
         $definitionWithNoArguments = new Definition();
 
@@ -72,7 +72,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
     /**
      * @return \Generator
      */
-    public function invalid_definition_indexes()
+    public static function invalid_definition_indexes()
     {
         yield [
             new \stdClass(), 'Expected either a string or a positive integer for $argumentIndex.',
@@ -133,7 +133,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
     /**
      * @return \Generator
      */
-    public function indexed_arguments()
+    public static function indexed_arguments()
     {
         // yield [0];
         yield [1];
@@ -181,7 +181,7 @@ class DefinitionHasArgumentConstraintTest extends TestCase
     /**
      * @return \Generator
      */
-    public function named_arguments()
+    public static function named_arguments()
     {
         yield ['$foo'];
         yield ['$bar'];

--- a/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
@@ -19,7 +19,7 @@ class DefinitionHasMethodCallConstraintTest extends TestCase
         $this->assertSame($expectedToMatch, $constraint->evaluate($definition, '', true));
     }
 
-    public function definitionProvider()
+    public static function definitionProvider()
     {
         $definitionWithNoMethodCalls = new Definition();
 

--- a/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
@@ -10,6 +10,7 @@ class DefinitionHasMethodCallConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider definitionProvider
      */
     public function match(Definition $definition, $method, $arguments, $index, $expectedToMatch): void

--- a/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
@@ -40,7 +40,7 @@ class DefinitionHasTagConstraintTest extends TestCase
         }
     }
 
-    public function definitionProvider()
+    public static function definitionProvider()
     {
         $definitionWithoutTags = new Definition();
         $definitionWithTwoTags = new Definition();

--- a/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
@@ -11,6 +11,7 @@ class DefinitionHasTagConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider definitionProvider
      */
     public function match(Definition $definition, $tag, $attributes, $expectedToMatch): void
@@ -22,6 +23,7 @@ class DefinitionHasTagConstraintTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider definitionProvider
      */
     public function evaluateThrowsExceptionOnFailure(Definition $definition, $tag, $attributes, $expectedToMatch): void

--- a/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
@@ -21,7 +21,7 @@ class DefinitionIsChildOfConstraintTest extends TestCase
         $this->assertSame($expectedToMatch, $constraint->evaluate($definition, '', true));
     }
 
-    public function definitionProvider()
+    public static function definitionProvider()
     {
         $definition = new Definition();
         if (class_exists(ChildDefinition::class)) {

--- a/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
@@ -12,6 +12,7 @@ class DefinitionIsChildOfConstraintTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider definitionProvider
      */
     public function match(Definition $definition, $parentServiceId, $expectedToMatch): void

--- a/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
@@ -24,11 +24,7 @@ class DefinitionIsChildOfConstraintTest extends TestCase
     public static function definitionProvider()
     {
         $definition = new Definition();
-        if (class_exists(ChildDefinition::class)) {
-            $decoratedDefinition = new ChildDefinition('parent_service_id');
-        } else {
-            $decoratedDefinition = new DefinitionDecorator('parent_service_id');
-        }
+        $decoratedDefinition = new ChildDefinition('parent_service_id');
 
         return [
             // the provided definition has the same parent service id

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "matthiasnoback/symfony-config-test": "^4.0.1",
-        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
-        "symfony/config": "^4.4 || ^5.3 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.3 || ^6.0"
+        "php": "^8.1",
+        "matthiasnoback/symfony-config-test": "^5.0",
+        "symfony/dependency-injection": "^5.4 || ^6.2",
+        "symfony/config": "^5.4 || ^6.2",
+        "symfony/yaml": "^5.4 || ^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "^9.6 || ^10.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<8.0"
+        "phpunit/phpunit": "<9.6 || >=11.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" },
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0.x-dev"
+            "dev-master": "5.0.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
+         colors="true"
+>
     <testsuites>
         <testsuite name="SymfonyDependencyInjectionTest">
-            <directory suffix="Test.php">Tests</directory>
+            <directory>Tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory>Tests</directory>
-                <directory>vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
This is much the same approach as I used for https://github.com/SymfonyTest/SymfonyConfigTest/pull/73, but now for this package.  Overall gist of the changes:

- Require Symfony 5.4, 6.2-6.4
- Require PHP 8.1+
- Require PHPUnit 9.6 or 10.x
- Removes unnecessary B/C checks

The one "hard" B/C break is the removal of `LoaderFactory::createIniFileLoader()` as INI support is untested and there aren't many test fixtures for this even in Symfony's repo to set something up to at least cover it (doubt this actually has a major impact).