### PR TITLE
Use the PHPUnit Exporter util class

### DIFF
--- a/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
+++ b/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php
@@ -4,7 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
@@ -12,7 +12,6 @@ final class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
     private $serviceId;
     private $expectedClass;
     private $checkExpectedClass;
-    private $exporter;
 
     public function __construct(
         string $serviceId,
@@ -22,7 +21,6 @@ final class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
         $this->serviceId = $serviceId;
         $this->expectedClass = $expectedClass;
         $this->checkExpectedClass = $checkExpectedClass;
-        $this->exporter = new Exporter();
     }
 
     public function toString(): string
@@ -88,8 +86,8 @@ final class ContainerBuilderHasServiceDefinitionConstraint extends Constraint
             $this->fail($containerBuilder, sprintf(
                 'The class of the service definition of "%s" (%s) does not match the expected value (%s)',
                 $this->serviceId,
-                $this->exporter->export($actualClass),
-                $this->exporter->export($this->expectedClass)
+                Exporter::export($actualClass),
+                Exporter::export($this->expectedClass)
             ));
         }
 

--- a/PhpUnit/ContainerHasParameterConstraint.php
+++ b/PhpUnit/ContainerHasParameterConstraint.php
@@ -5,7 +5,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\IsIdentical;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class ContainerHasParameterConstraint extends Constraint
@@ -14,7 +14,6 @@ final class ContainerHasParameterConstraint extends Constraint
     private $expectedParameterValue;
     private $checkParameterValue;
     private $strict;
-    private $exporter;
 
     public function __construct(
         string $parameterName,
@@ -26,7 +25,6 @@ final class ContainerHasParameterConstraint extends Constraint
         $this->expectedParameterValue = $expectedParameterValue;
         $this->checkParameterValue = $checkParameterValue;
         $this->strict = $strict;
-        $this->exporter = new Exporter();
     }
 
     public function toString(): string
@@ -86,8 +84,8 @@ final class ContainerHasParameterConstraint extends Constraint
             $this->fail($container, sprintf(
                 'The value of parameter "%s" (%s) does not match the expected value (%s)',
                 $this->parameterName,
-                $this->exporter->export($actualValue),
-                $this->exporter->export($this->expectedParameterValue)
+                Exporter::export($actualValue),
+                Exporter::export($this->expectedParameterValue)
             ));
         }
 

--- a/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionArgumentEqualsServiceLocatorConstraint.php
@@ -4,7 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -20,7 +20,6 @@ final class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
     private $argumentIndex;
     private $expectedValue;
     private $serviceId;
-    private $exporter;
 
     public function __construct(string $serviceId, $argumentIndex, array $expectedValue)
     {
@@ -56,8 +55,6 @@ final class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
             },
             $expectedValue
         );
-
-        $this->exporter = new Exporter();
     }
 
     public function toString(): string
@@ -130,7 +127,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
                 sprintf(
                     'The value of argument with index %s (%s) was expected to an instance of Symfony\Component\DependencyInjection\Reference or \Symfony\Component\DependencyInjection\Definition',
                     $this->argumentIndex,
-                    $this->exporter->export($actualValue)
+                    Exporter::export($actualValue)
                 )
             );
         }
@@ -145,7 +142,7 @@ final class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
                 sprintf(
                     'The referenced service class of argument with index %s (%s) was expected to be an instance of Symfony\Component\DependencyInjection\ServiceLocator',
                     $this->argumentIndex,
-                    $this->exporter->export($serviceLocatorDef->getClass())
+                    Exporter::export($serviceLocatorDef->getClass())
                 )
             );
         }
@@ -176,8 +173,8 @@ final class DefinitionArgumentEqualsServiceLocatorConstraint extends Constraint
                 sprintf(
                     'The value of argument with index %s (%s) does not equal to the expected ServiceLocator service-map (%s)',
                     $this->argumentIndex,
-                    $this->exporter->export($actualValue),
-                    $this->exporter->export($this->expectedValue)
+                    Exporter::export($actualValue),
+                    Exporter::export($this->expectedValue)
                 )
             );
         }

--- a/PhpUnit/DefinitionEqualsServiceLocatorConstraint.php
+++ b/PhpUnit/DefinitionEqualsServiceLocatorConstraint.php
@@ -4,7 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -13,7 +13,6 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 final class DefinitionEqualsServiceLocatorConstraint extends Constraint
 {
     private $expectedValue;
-    private $exporter;
 
     public function __construct($expectedValue)
     {
@@ -31,7 +30,6 @@ final class DefinitionEqualsServiceLocatorConstraint extends Constraint
             },
             $expectedValue
         );
-        $this->exporter = new Exporter();
     }
 
     public function toString(): string
@@ -73,8 +71,8 @@ final class DefinitionEqualsServiceLocatorConstraint extends Constraint
             $definition,
             sprintf(
                 'class %s was expected as service definition class, found %s instead',
-                $this->exporter->export(ServiceLocator::class),
-                $this->exporter->export($definition->getClass())
+                Exporter::export(ServiceLocator::class),
+                Exporter::export($definition->getClass())
             )
         );
     }
@@ -93,8 +91,8 @@ final class DefinitionEqualsServiceLocatorConstraint extends Constraint
                 $definition,
                 sprintf(
                     'The service-map %s does not equal to the expected service-map (%s)',
-                    $this->exporter->export($actualValue),
-                    $this->exporter->export($this->expectedValue)
+                    Exporter::export($actualValue),
+                    Exporter::export($this->expectedValue)
                 )
             );
         }

--- a/PhpUnit/DefinitionHasArgumentConstraint.php
+++ b/PhpUnit/DefinitionHasArgumentConstraint.php
@@ -4,7 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
@@ -16,7 +16,6 @@ final class DefinitionHasArgumentConstraint extends Constraint
     private string|int $argumentIndex;
     private mixed $expectedValue;
     private bool $checkExpectedValue;
-    private Exporter $exporter;
 
     public function __construct($argumentIndex, $expectedValue, bool $checkExpectedValue = true)
     {
@@ -39,7 +38,6 @@ final class DefinitionHasArgumentConstraint extends Constraint
         $this->argumentIndex = $argumentIndex;
         $this->expectedValue = $expectedValue;
         $this->checkExpectedValue = $checkExpectedValue;
-        $this->exporter = new Exporter();
     }
 
     public function toString(): string
@@ -107,8 +105,8 @@ final class DefinitionHasArgumentConstraint extends Constraint
                 sprintf(
                     'The value of argument named "%s" (%s) is not equal to the expected value (%s)',
                     $this->argumentIndex,
-                    $this->exporter->export($actualValue),
-                    $this->exporter->export($this->expectedValue)
+                    Exporter::export($actualValue),
+                    Exporter::export($this->expectedValue)
                 )
             );
         }
@@ -124,15 +122,15 @@ final class DefinitionHasArgumentConstraint extends Constraint
                 $message = sprintf(
                     'The value of argument named "%s" (%s) is not equal to the expected value (%s)',
                     $this->argumentIndex,
-                    $this->exporter->export($actualValue),
-                    $this->exporter->export($this->expectedValue)
+                    Exporter::export($actualValue),
+                    Exporter::export($this->expectedValue)
                 );
             } else {
                 $message = sprintf(
                     'The value of argument with index %d (%s) is not equal to the expected value (%s)',
                     $this->argumentIndex,
-                    $this->exporter->export($actualValue),
-                    $this->exporter->export($this->expectedValue)
+                    Exporter::export($actualValue),
+                    Exporter::export($this->expectedValue)
                 );
             }
 

--- a/PhpUnit/DefinitionHasMethodCallConstraint.php
+++ b/PhpUnit/DefinitionHasMethodCallConstraint.php
@@ -4,7 +4,7 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\Definition;
 
 final class DefinitionHasMethodCallConstraint extends Constraint
@@ -12,7 +12,6 @@ final class DefinitionHasMethodCallConstraint extends Constraint
     private $methodName;
     private $arguments;
     private $index;
-    private $exporter;
 
     public function __construct(string $methodName, array $arguments = [], $index = null)
     {
@@ -23,7 +22,6 @@ final class DefinitionHasMethodCallConstraint extends Constraint
         $this->methodName = $methodName;
         $this->arguments = $arguments;
         $this->index = $index;
-        $this->exporter = new Exporter();
     }
 
     public function evaluate($other, string $description = '', bool $returnResult = false): bool
@@ -58,7 +56,7 @@ final class DefinitionHasMethodCallConstraint extends Constraint
                 sprintf(
                     'None of the method calls matched the expected method "%s" with arguments %s with %s invocation order index',
                     $this->methodName,
-                    $this->exporter->export($this->arguments),
+                    Exporter::export($this->arguments),
                     (null === $this->index) ? 'any' : sprintf('"%s"', $this->index)
                 )
             );

--- a/PhpUnit/DefinitionHasTagConstraint.php
+++ b/PhpUnit/DefinitionHasTagConstraint.php
@@ -4,20 +4,18 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\Exporter;
 use Symfony\Component\DependencyInjection\Definition;
 
 final class DefinitionHasTagConstraint extends Constraint
 {
     private $name;
     private $attributes;
-    private $exporter;
 
     public function __construct(string $name, array $attributes = [])
     {
         $this->name = $name;
         $this->attributes = $attributes;
-        $this->exporter = new Exporter();
     }
 
     public function evaluate($other, string $description = '', bool $returnResult = false): bool
@@ -45,7 +43,7 @@ final class DefinitionHasTagConstraint extends Constraint
                     sprintf(
                         'None of the tags matched the expected name "%s" with attributes %s',
                         $this->name,
-                        $this->exporter->export($this->attributes)
+                        Exporter::export($this->attributes)
                     )
                 );
             }

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ container:
 
 | Version | Released     | PHPUnit             | Status     |
 |---------|--------------|---------------------|------------|
-| 6.x     | Aug 8, 2024  | 10.5, 11.x and 12.x | Latest     |
+| 6.x     | Aug 8, 2024  | 10.5, 11.5 and 12.x | Latest     |
 | 5.x     | Nov 22, 2023 | 9.6 and 10.x        | Bugfixes   |
 | 4.x     | Mar 28, 2019 | 8.x and 9.x         | Bugfixes   |
 | 3.x     | Mar 5, 2018  | 7.x                 | Bugfixes   |

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": "^8.1",
         "matthiasnoback/symfony-config-test": "^5.0 || ^6.0",
-        "phpunit/phpunit": "^10.5.11 || ^11.0 || ^12.0",
-        "sebastian/exporter": " ^5.0 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^10.5.11 || ^11.5 || ^12.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
Alternative to #159
Fixes #158

PHPUnit 10.5, 11.3-11.5, and 12.0 all have a `PHPUnit\Util\Exporter` class which proxies to the `sebastian/exporter` package.  It is deprecated in 10.5, removed from 11.0, and restored in 11.3.  To avoid the issue reported in #158, this PR makes use of that utility class and removes the direct uses of and dependency to `sebastian/exporter`.

I've also bumped the minimum PHPUnit version for the 11.x branch to 11.5 because at this point the older branches are unsupported so not having to deal with differing behavior in the 3 minor versions this class doesn't exist in seems like a win.