### PR TITLE
Add support for PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^8.1",
         "matthiasnoback/symfony-config-test": "^5.0 || ^6.0",
-        "phpunit/phpunit": "^10.5.11 || ^11.5 || ^12.0",
+        "phpunit/phpunit": "^10.5.11 || ^11.5 || ^12.0 || ^13.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
This change updates the PHPUnit dependency constraint to support version 13.0 and above, in addition to the previously supported versions.

## Summary
Extended PHPUnit version compatibility to include the latest major version (13.0) while maintaining backward compatibility with existing supported versions (10.5.11, 11.5, and 12.0).

## Changes
- Updated `phpunit/phpunit` version constraint from `^10.5.11 || ^11.5 || ^12.0` to `^10.5.11 || ^11.5 || ^12.0 || ^13.0`

This allows the package to work with PHPUnit 13.0 and future minor/patch releases within the 13.x branch.

https://claude.ai/code/session_01LRy8BQjokyWrEaor5VtfYF